### PR TITLE
feat: generate valid passwords when using additional validators

### DIFF
--- a/lms/djangoapps/support/views/manage_user.py
+++ b/lms/djangoapps/support/views/manage_user.py
@@ -17,8 +17,7 @@ from common.djangoapps.util.json_request import JsonResponse
 from lms.djangoapps.support.decorators import require_support_permission
 from openedx.core.djangoapps.user_api.accounts.serializers import AccountUserSerializer
 from openedx.core.djangolib.oauth2_retirement_utils import retire_dot_oauth2_models
-
-from edx_django_utils.user import generate_password  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx.core.djangoapps.user_authn.utils import generate_password
 
 
 class ManageUserSupportView(View):

--- a/openedx/core/djangoapps/user_api/management/commands/cancel_user_retirement_request.py
+++ b/openedx/core/djangoapps/user_api/management/commands/cancel_user_retirement_request.py
@@ -11,7 +11,6 @@ from django.core.management.base import BaseCommand, CommandError
 
 from openedx.core.djangoapps.user_api.accounts.utils import handle_retirement_cancellation
 from openedx.core.djangoapps.user_api.models import UserRetirementStatus
-from openedx.core.djangoapps.user_authn.utils import generate_password
 
 LOGGER = logging.getLogger(__name__)
 

--- a/openedx/core/djangoapps/user_api/management/commands/cancel_user_retirement_request.py
+++ b/openedx/core/djangoapps/user_api/management/commands/cancel_user_retirement_request.py
@@ -11,6 +11,7 @@ from django.core.management.base import BaseCommand, CommandError
 
 from openedx.core.djangoapps.user_api.accounts.utils import handle_retirement_cancellation
 from openedx.core.djangoapps.user_api.models import UserRetirementStatus
+from openedx.core.djangoapps.user_authn.utils import generate_password
 
 LOGGER = logging.getLogger(__name__)
 

--- a/openedx/core/djangoapps/user_authn/utils.py
+++ b/openedx/core/djangoapps/user_authn/utils.py
@@ -6,6 +6,8 @@ import hashlib
 import math
 import random
 import re
+import string
+
 from urllib.parse import urlparse  # pylint: disable=import-error
 from uuid import uuid4  # lint-amnesty, pylint: disable=unused-import
 
@@ -61,6 +63,97 @@ def is_safe_login_or_logout_redirect(redirect_to, request_host, dot_client_id, r
     )
 
     return is_safe_url
+
+
+def password_rules():
+    """
+    Inspect the validators defined in AUTH_PASSWORD_VALIDATORS and define
+    a rule list with the set of available characters and their minimum
+    for a specific charset category (alphabetic, digits, uppercase, etc).
+
+    This is based on the validators defined in
+    common.djangoapps.util.password_policy_validators and
+    django_password_validators.password_character_requirements.password_validation.PasswordCharacterValidator
+    """
+    password_validators = settings.AUTH_PASSWORD_VALIDATORS
+    rules = {
+        "alpha": [string.ascii_letters, 0],
+        "digit": [string.digits, 0],
+        "upper": [string.ascii_uppercase, 0],
+        "lower": [string.ascii_lowercase, 0],
+        "punctuation": [string.punctuation, 0],
+        "symbol": ["£¥€©®™†§¶πμ'±", 0],
+        "min_length": ["", 0],
+    }
+    options_mapping = {
+        "min_alphabetic": "alpha",
+        "min_length_alpha": "alpha",
+        "min_length_digit": "digit",
+        "min_length_upper": "upper",
+        "min_length_lower": "lower",
+        "min_lower": "lower",
+        "min_upper": "upper",
+        "min_numeric": "digit",
+        "min_symbol": "symbol",
+        "min_punctuation": "punctuation",
+    }
+
+    for validator in password_validators:
+        for option, mapping in options_mapping.items():
+            if not validator.get("OPTIONS"):
+                continue
+            rules[mapping][1] = max(
+                rules[mapping][1], validator["OPTIONS"].get(option, 0)
+            )
+        # We handle PasswordCharacterValidator separately because it can define
+        # its own set of special characters.
+        if (
+            validator["NAME"] ==
+            "django_password_validators.password_character_requirements.password_validation.PasswordCharacterValidator"
+        ):
+            min_special = validator["OPTIONS"].get("min_length_special", 0)
+            special_chars = validator["OPTIONS"].get(
+                "special_characters", "~!@#$%^&*()_+{}\":;'[]"
+            )
+            rules["special"] = [special_chars, min_special]
+
+    return rules
+
+
+def generate_password(length=12, chars=string.ascii_letters + string.digits):
+    """Generate a valid random password.
+
+    The original `generate_password` doesn't account for extra validators
+    This picks the minimum amount of characters for each charset category.
+    """
+    if length < 8:
+        raise ValueError("password must be at least 8 characters")
+
+    password = ""
+    password_length = length
+    choice = random.SystemRandom().choice
+    rules = password_rules()
+    min_length = rules.pop("min_length")[1]
+    password_length = max(min_length, length)
+
+    for elems in rules.values():
+        choices = elems[0]
+        needed = elems[1]
+        for _ in range(needed):
+            next_char = choice(choices)
+            password += next_char
+
+    # fill the password to reach password_length
+    if len(password) < password_length:
+        password += "".join(
+            [choice(chars) for _ in range(password_length - len(password))]
+        )
+
+    password_list = list(password)
+    random.shuffle(password_list)
+
+    password = "".join(password_list)
+    return password
 
 
 def is_registration_api_v1(request):

--- a/openedx/core/djangoapps/user_authn/views/auto_auth.py
+++ b/openedx/core/djangoapps/user_authn/views/auto_auth.py
@@ -35,8 +35,7 @@ from common.djangoapps.student.models import (
     create_comments_service_user
 )
 from common.djangoapps.util.json_request import JsonResponse
-
-from edx_django_utils.user import generate_password  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx.core.djangoapps.user_authn.utils import generate_password
 
 
 def auto_auth(request):  # pylint: disable=too-many-statements

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -57,7 +57,7 @@ from openedx.core.djangoapps.user_api.accounts.api import (
 from openedx.core.djangoapps.user_api.preferences import api as preferences_api
 from openedx.core.djangoapps.user_authn.cookies import set_logged_in_cookies
 from openedx.core.djangoapps.user_authn.utils import (
-    generate_username_suggestions, is_registration_api_v1
+    generate_password, generate_username_suggestions, is_registration_api_v1
 )
 from openedx.core.djangoapps.user_authn.views.registration_form import (
     AccountCreationForm,
@@ -85,8 +85,6 @@ from common.djangoapps.third_party_auth.saml import SAP_SUCCESSFACTORS_SAML_KEY
 from common.djangoapps.track import segment
 from common.djangoapps.util.db import outer_atomic
 from common.djangoapps.util.json_request import JsonResponse
-
-from edx_django_utils.user import generate_password  # lint-amnesty, pylint: disable=wrong-import-order
 
 log = logging.getLogger("edx.student")
 AUDIT_LOG = logging.getLogger("audit")


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

(cherry picked from commit d21be1bb1a3d0171567b047442e136ebb8c01d3e)

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

install django-password-validators=1.7, set correct settings, add the package to installed apps and migrate it.
![Peek 2024-01-22 15-01](https://github.com/nelc/edx-platform/assets/51926076/1a8850c2-d010-45b6-9688-8ed43f398410)
[Screencast from 22-01-24 15:13:17.webm](https://github.com/nelc/edx-platform/assets/51926076/a9f351f5-d906-49de-9b51-7797fbdeec07)



### Before

[Screencast from 22-01-24 15:10:49.webm](https://github.com/nelc/edx-platform/assets/51926076/423c4f4a-7f79-4c8f-a3ff-266aa60d2c63)

## After
[Screencast from 22-01-24 15:15:17.webm](https://github.com/nelc/edx-platform/assets/51926076/1d52b6be-8014-4566-a552-e9231d8033a3)

## Other information

PRs related
https://github.com/edunext/edunext-platform/pull/676
