### PR TITLE
feat: add a setting flag to control user pref lang

### DIFF
--- a/openedx/core/djangoapps/lang_pref/middleware.py
+++ b/openedx/core/djangoapps/lang_pref/middleware.py
@@ -57,8 +57,8 @@ class LanguagePreferenceMiddleware(MiddlewareMixin):
             if LANGUAGE_SESSION_KEY in request.session and request.session[LANGUAGE_SESSION_KEY] != cookie_lang:
                 del request.session[LANGUAGE_SESSION_KEY]
 
-        # Apply language specified in SiteConfiguration, ignoring user preferences.
-        if (language := get_value('LANGUAGE_CODE')) and (getattr(settings, "IGNORE_USER_LANGUAGE_COOKIE", True)):
+        # Apply language specified in SiteConfiguration, if there are not user preferences.
+        if (language := get_value('LANGUAGE_CODE')) and (not request.COOKIES.get(settings.LANGUAGE_COOKIE_NAME, None)):
             request.COOKIES[settings.LANGUAGE_COOKIE_NAME] = language
 
     def process_response(self, request, response):  # lint-amnesty, pylint: disable=missing-function-docstring

--- a/openedx/core/djangoapps/lang_pref/middleware.py
+++ b/openedx/core/djangoapps/lang_pref/middleware.py
@@ -58,7 +58,7 @@ class LanguagePreferenceMiddleware(MiddlewareMixin):
                 del request.session[LANGUAGE_SESSION_KEY]
 
         # Apply language specified in SiteConfiguration, ignoring user preferences.
-        if language := get_value('LANGUAGE_CODE'):
+        if (language := get_value('LANGUAGE_CODE')) and (getattr(settings, "IGNORE_USER_LANGUAGE_COOKIE", True)):
             request.COOKIES[settings.LANGUAGE_COOKIE_NAME] = language
 
     def process_response(self, request, response):  # lint-amnesty, pylint: disable=missing-function-docstring


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This is migration issue. 

This add a setting variable that allow to show if the LANGUAGE_CODE of the site config would have more priority than the cookie of the user preference. The setting is `IGNORE_USER_LANGUAGE_COOKIE`, so by default the site config `LANGUAGE_CODE` woul have more prior but if the setting is set to False the user cookie would work.

**migration context**
The [commit](https://github.com/edunext/edunext-platform/commit/c8663e7d1bacacb6a1589e1cf9ca26296042fbc3) of the migration could not be applied due [openedx](https://github.com/openedx/edx-platform/pull/31408/files#diff-60ff6a004fc92bf14bb5c8a6c12e2bb683d238a5450a9dd449151698270ffdad)  change dark_lang middleware and set by default site_config language_code priority over the cookie. You can check that the function [_set_site_or_microsite_language](https://github.com/openedx/edx-platform/pull/31408/files#diff-60ff6a004fc92bf14bb5c8a6c12e2bb683d238a5450a9dd449151698270ffdadL106)  was removed.




## Testing instructions

Use eox-tenant and set `LANGUAGE_CODE`. you can see there the cookie would be ignored.

### Before 
[Screencast from 22-01-24 16:57:30.webm](https://github.com/nelc/edx-platform/assets/51926076/f3920af4-e863-4493-9c89-e4893de5a13b)

### After
[Screencast from 22-01-24 17:07:23.webm](https://github.com/nelc/edx-platform/assets/51926076/95a8a28c-88e2-4b90-abe1-47f979cf91a0)

## Supporting information

PRS related.
https://github.com/edunext/edunext-platform/pull/672
