### PR TITLE
feat: Make studio link tenant aware and remove preview

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -104,7 +104,7 @@ def _remove_instructors(course_key):
         log.error(f"Error in deleting course groups for {course_key}: {err}")
 
 
-def get_lms_link_for_item(location, preview=False):
+def get_lms_link_for_item(location, preview=False):  # pylint: disable=unused-argument
     """
     Returns an LMS link to the course with a jump_to to the provided location.
 
@@ -123,15 +123,6 @@ def get_lms_link_for_item(location, preview=False):
 
     if lms_base is None:
         return None
-
-    if preview:
-        # checks PREVIEW_LMS_BASE value in site configuration for the given course_org_filter(org)
-        # if not found returns settings.FEATURES.get('PREVIEW_LMS_BASE')
-        lms_base = SiteConfiguration.get_value_for_org(
-            location.org,
-            "PREVIEW_LMS_BASE",
-            settings.FEATURES.get('PREVIEW_LMS_BASE')
-        )
 
     return "//{lms_base}/courses/{course_key}/jump_to/{location}".format(
         lms_base=lms_base,

--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -598,7 +598,12 @@ def _get_asset_json(display_name, content_type, date, location, thumbnail_locati
     Helper method for formatting the asset information to send to client.
     '''
     asset_url = StaticContent.serialize_asset_key_with_slash(location)
-    external_url = urljoin(configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL), asset_url)
+    lms_root = configuration_helpers.get_value_for_org(
+        location.org,
+        'LMS_ROOT_URL',
+        settings.LMS_ROOT_URL
+    )
+    external_url = urljoin(lms_root, asset_url)
     portable_url = StaticContent.get_static_path_from_location(location)
     return {
         'display_name': display_name,

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -138,7 +138,7 @@ from openedx.core.djangolib.markup import HTML, Text
                             <span class="action-button-text">${_("View Live Version")}</span>
                         </a>
                     </li>
-                    <li class="action-item action-preview nav-item">
+                    <li class="action-item action-preview nav-item" style="display: none">
                         <a href="${draft_preview_link}" class="button button-preview action-button" rel="external" title="${_('Preview the courseware in the LMS')}">
                             <span class="action-button-text">${_("Preview")}</span>
                         </a>

--- a/common/djangoapps/util/course.py
+++ b/common/djangoapps/util/course.py
@@ -54,8 +54,14 @@ def get_link_for_about_page(course):
     elif settings.FEATURES.get('ENABLE_MKTG_SITE') and getattr(course, 'marketing_url', None):
         course_about_url = course.marketing_url
     else:
+        about_base = configuration_helpers.get_value_for_org(
+            course.id.org,
+            'LMS_ROOT_URL',
+            settings.LMS_ROOT_URL
+        )
+
         course_about_url = '{about_base_url}/courses/{course_key}/about'.format(
-            about_base_url=configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
+            about_base_url=about_base,
             course_key=str(course.id),
         )
 


### PR DESCRIPTION

<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description
Migration PR
(cherry picked from commit c54866cb68df32f0b2d06c57851bcd358e82d63b)


## Testing instructions

Check the following in studio:
-  the url of about in schedule and details view is tenant aware.
-  the preview buttton is removed in the units.
### Before
[Screencast from 22-01-24 18:09:31.webm](https://github.com/nelc/edx-platform/assets/51926076/807708e2-ecf6-4390-9cb6-a7906920a01a)
### After
[Screencast from 22-01-24 18:11:55.webm](https://github.com/nelc/edx-platform/assets/51926076/14f5522e-8a57-4461-bd0b-b6a18e9a9b02)





## Other information
 Prs related
https://github.com/edunext/edunext-platform/pull/685
https://github.com/eduNEXT/edunext-platform/pull/560