### PR TITLE
feat: Add course type field to advanced settings and course info index

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -589,6 +589,7 @@ class CourseAboutSearchIndexer(CoursewareSearchIndexer):
         AboutInfo("language", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("invitation_only", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("catalog_visibility", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
+        AboutInfo("course_type", AboutInfo.ANALYSE | AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
     ]
 
     @classmethod

--- a/xmodule/course_block.py
+++ b/xmodule/course_block.py
@@ -1041,6 +1041,15 @@ class CourseFields:  # lint-amnesty, pylint: disable=missing-class-docstring
         scope=Scope.settings
     )
 
+    course_type = String(
+        display_name=_("Course Type"),
+        help=_(
+            "Content type that helps the student to filter courses which are more interesting for them."
+        ),
+        default=None,
+        scope=Scope.settings,
+    )
+
 
 class CourseBlock(
     CourseFields,


### PR DESCRIPTION

<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Migration pr
(cherry picked from commit f5cb2171255cb0b4d8d1f5f9c0b386565ce76e1c)

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Go to studio and add the course_type in advance settings.
## Before
![Screenshot from 2024-01-22 18-45-17](https://github.com/nelc/edx-platform/assets/51926076/7a22ab91-e291-4147-87d5-36f3a6044fd2)


## After

[Screencast from 22-01-24 18:45:51.webm](https://github.com/nelc/edx-platform/assets/51926076/69b2af3b-f244-4fef-9320-14a383222e2d)
If you want you can check it mongo.

![2024-01-22_18-53](https://github.com/nelc/edx-platform/assets/51926076/5d1a0713-1f63-4b38-ba39-438a994a38e7)



## Other information

PRs related
https://github.com/eduNEXT/edunext-platform/pull/709
