### PR TITLE
feat: Add setting DISABLE_ORDER_HISTORY_TAB

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -159,7 +159,10 @@ def account_settings_context(request):
         'show_program_listing': ProgramsApiConfig.is_enabled(),
         'show_dashboard_tabs': True,
         'order_history': user_orders,
-        'disable_order_history_tab': should_redirect_to_order_history_microfrontend(),
+        'disable_order_history_tab': (
+            configuration_helpers.get_value('DISABLE_ORDER_HISTORY_TAB', False)
+            or should_redirect_to_order_history_microfrontend()
+        ),
         'show_linked_accounts_tab': should_show_linked_accounts_tab(),
         'enable_account_deletion': configuration_helpers.get_value(
             'ENABLE_ACCOUNT_DELETION', settings.FEATURES.get('ENABLE_ACCOUNT_DELETION', False)


### PR DESCRIPTION

<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description
Migration Pr 
(cherry picked from commit c3e66c0f350a1725a1d087fd23cea0a1c649ff2b)




## Testing instructions
### Deactivate mfe account settings. This change is only for the base or classic account settings view. Mfe doesnt works.

Deactivate the order tab  using django site config or eox-tenant if you have it or django settings.
``` json
 "DISABLE_ORDER_HISTORY_TAB": true
```

### Before
![before_order_tab](https://github.com/nelc/edx-platform/assets/51926076/3aeb4d61-a7c6-423b-993d-2bd67a30fa52)


### After
![after_order_tab](https://github.com/nelc/edx-platform/assets/51926076/41685a79-2cba-4855-abdb-ba8fb0e17ddb)




## Other information
Prs related
https://github.com/eduNEXT/edunext-platform/pull/683 