### PR TITLE
feat: this allows to change the editable behavior for the full name f…

### DIFF
--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -32,7 +32,8 @@
             extendedProfileFields,
             displayAccountDeletion,
             isSecondaryEmailFeatureEnabled,
-            betaLanguage
+            betaLanguage,
+            allowFullNameChange
         ) {
             var $accountSettingsElement, userAccountModel, userPreferencesModel, aboutSectionsData,
                 accountsSectionData, ordersSectionData, accountSettingsView, showAccountSettingsPage,
@@ -104,7 +105,7 @@
                 helpMessage: gettext('The name that is used for ID verification and that appears on your certificates.'),  // eslint-disable-line max-len,
                 persistChanges: true
             };
-            if (syncLearnerProfileData && enterpriseReadonlyAccountFields.fields.indexOf('name') !== -1) {
+            if (!allowFullNameChange || (syncLearnerProfileData && enterpriseReadonlyAccountFields.fields.indexOf('name') !== -1)) {
                 fullnameFieldView = {
                     view: new AccountSettingsFieldViews.ReadonlyFieldView(fullNameFieldData)
                 };

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -40,6 +40,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
         contactEmail = '${ static.get_contact_email_address() | n, js_escaped_string }',
         allowEmailChange = ${ bool(settings.FEATURES['ALLOW_EMAIL_ADDRESS_CHANGE']) | n, dump_js_escaped_json },
         socialPlatforms = ${ settings.SOCIAL_PLATFORMS | n, dump_js_escaped_json },
+        allowFullNameChange = ${ bool(settings.FEATURES.get('ALLOW_FULL_NAME_CHANGE')) | n, dump_js_escaped_json },
 
         syncLearnerProfileData = ${ bool(sync_learner_profile_data) | n, dump_js_escaped_json },
         enterpriseName = '${ enterprise_name | n, js_escaped_string }',
@@ -74,6 +75,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
         displayAccountDeletion,
         isSecondaryEmailFeatureEnabled,
         ${ beta_language | n, dump_js_escaped_json },
+        allowFullNameChange,
     );
 </%static:require_module>
 


### PR DESCRIPTION

<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Migration PR

https://edunext.atlassian.net/browse/FUTUREX-521
(cherry picked from commit https://github.com/nelc/edx-platform/commit/f9176f159b711b5f542530d30aede429c2b53186)

## Testing instructions

### Deactivate mfe account settings. This change is only for the base or classic account settings view. Mfe doesnt works.

Hide fullname change   using django site config or eox-tenant if you have it or django settings.
``` python
FEATURES["ALLOW_FULL_NAME_CHANGE"] = False
```
### Before
![2024-01-23_09-48](https://github.com/nelc/edx-platform/assets/51926076/324174e9-ad95-4d4d-9c3d-7fdd79dab5fb)

### After
![2024-01-23_10-04](https://github.com/nelc/edx-platform/assets/51926076/11106fe3-56d7-453c-963b-890813cc9a77)


## Other information

PRs related
https://github.com/eduNEXT/edunext-platform/pull/779
