### PR TITLE
feat: Allow to include translations for extended profile fields

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -272,12 +272,14 @@ def _get_extended_profile_fields():
         "specialty": _("Specialty")
     }
     request = theming_helpers.get_current_request()
-    extended_profile_fields_translations = configuration_helpers.get_value(
-        'extended_profile_fields_translations',
-        {},
-    )
-    translations = extended_profile_fields_translations.get(request.LANGUAGE_CODE, {})
-    field_labels_map.update(translations)
+
+    if request:
+        extended_profile_fields_translations = configuration_helpers.get_value(
+            'extended_profile_fields_translations',
+            {},
+        )
+        translations = extended_profile_fields_translations.get(request.LANGUAGE_CODE, {})
+        field_labels_map.update(translations)
 
     extended_profile_field_names = configuration_helpers.get_value('extended_profile_fields', [])
     for field_to_exclude in fields_already_showing:

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -28,6 +28,7 @@ from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.djangoapps.lang_pref.api import all_languages, released_languages
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.theming import helpers as theming_helpers
 from openedx.core.djangoapps.user_api.accounts.toggles import (
     should_redirect_to_account_microfrontend,
     should_redirect_to_order_history_microfrontend
@@ -270,6 +271,13 @@ def _get_extended_profile_fields():
         "profession": _("Profession"),
         "specialty": _("Specialty")
     }
+    request = theming_helpers.get_current_request()
+    extended_profile_fields_translations = configuration_helpers.get_value(
+        'extended_profile_fields_translations',
+        {},
+    )
+    translations = extended_profile_fields_translations.get(request.LANGUAGE_CODE, {})
+    field_labels_map.update(translations)
 
     extended_profile_field_names = configuration_helpers.get_value('extended_profile_fields', [])
     for field_to_exclude in fields_already_showing:


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Pr migration.
(cherry picked from commit 5d03359b2b503ab1e15f67f90eb9df6ae47d4ccc)



## Testing instructions
Install eox-nelp and some other packages need it like. 
``` bash
pip install edx-event-routing-backends
pip install git+https://github.com/eduNEXT/eox-nelp.git
```
Add the middleware of eox-nelp.
```python
MIDDLEWARE += [
    "eox_nelp.middleware.ExtendedProfileFieldsMiddleware",
]
```
Abd in tenant config the following.

``` json
    "REGISTRATION_EXTRA_FIELDS": {
        "city": "hidden",
        "confirm_email": "hidden",
        "country": "optional",
        "first_name": "required",
        "gender": "optional",
        "goals": "optional",
        "hobby": "optional",
        "honor_code": "required",
        "last_name": "required",
        "level_of_education": "optional",
        "mailing_address": "hidden",
        "movie": "optional",
        "sport": "optional",
        "terms_of_service": "hidden",
        "year_of_birth": "optional"
    },
    "extended_profile_fields": [
        "hobby",
        "sport",
        "movie"
    ],
    "extended_profile_fields_translations": {
        "ar": {
            "hobby": "\u0647\u0648\u0627\u064a\u0629",
            "movie": "\u0641\u064a\u0644\u0645",
            "sport": "\u0631\u064a\u0627\u0636\u0629"
        }
    }
```
Check translation works in account settings view changing the language.
### Before
![2024-01-23_16-53](https://github.com/nelc/edx-platform/assets/51926076/0bb4974b-b61d-43e8-9f01-8f4d428239b2)

### After
![2024-01-23_16-59](https://github.com/nelc/edx-platform/assets/51926076/a6700955-74db-4686-b2d3-4319a30ad0ce)


## Extra information

This need eox-nelp, to use the middleware of extended profile fields. For account settings view, the middleware is working but the register modal is not showing the custom fields using the `extended_profile_fields`.

![Screenshot from 2024-01-23 17-01-36](https://github.com/nelc/edx-platform/assets/51926076/1cad62c0-d992-4d16-ba6a-1d4089cd3ab3)

