### PR TITLE
fix: test only accepts int values in priority

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_tabs.py
+++ b/cms/djangoapps/contentstore/views/tests/test_tabs.py
@@ -191,7 +191,7 @@ class PrimitiveTabEdit(ModuleStoreTestCase):
             tabs.primitive_delete(course, 6)
 
         assert course.tabs[1] != {'type': 'dates', 'name': 'Dates'}
-        tabs.primitive_delete(course, -2)
+        tabs.primitive_delete(course, len(course.tabs) - 2)
         assert {'type': 'progress'} not in course.tabs
         # Check that dates has shifted up
         assert course.tabs[1] == {'type': 'dates', 'name': 'Dates'}

--- a/cms/djangoapps/contentstore/views/tests/test_tabs.py
+++ b/cms/djangoapps/contentstore/views/tests/test_tabs.py
@@ -191,7 +191,7 @@ class PrimitiveTabEdit(ModuleStoreTestCase):
             tabs.primitive_delete(course, 6)
 
         assert course.tabs[1] != {'type': 'dates', 'name': 'Dates'}
-        tabs.primitive_delete(course, 1)
+        tabs.primitive_delete(course, -2)
         assert {'type': 'progress'} not in course.tabs
         # Check that dates has shifted up
         assert course.tabs[1] == {'type': 'dates', 'name': 'Dates'}

--- a/cms/djangoapps/contentstore/views/tests/test_tabs.py
+++ b/cms/djangoapps/contentstore/views/tests/test_tabs.py
@@ -194,7 +194,7 @@ class PrimitiveTabEdit(ModuleStoreTestCase):
         tabs.primitive_delete(course, len(course.tabs) - 2)
         assert {'type': 'progress'} not in course.tabs
         # Check that dates has shifted up
-        assert course.tabs[1] == {'type': 'dates', 'name': 'Dates'}
+        assert course.tabs[-1] == {'type': 'dates', 'name': 'Dates'}
 
     def test_insert(self):
         """Test primitive tab insertion."""

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -61,6 +61,7 @@ class SyllabusTab(EnrolledTab):
     """
     type = 'syllabus'
     title = gettext_noop('Syllabus')
+    priority = 980
     view_name = 'syllabus'
     allow_multiple = True
     is_default = False
@@ -78,6 +79,7 @@ class ProgressTab(EnrolledTab):
     """
     type = 'progress'
     title = gettext_noop('Progress')
+    priority = 990
     view_name = 'progress'
     is_hideable = True
     is_default = False
@@ -303,6 +305,7 @@ class DatesTab(EnrolledTab):
     type = "dates"
     # We don't have the user in this context, so we don't want to translate it at this level.
     title = gettext_noop("Dates")
+    priority = 1000
     view_name = "dates"
 
     def __init__(self, tab_dict):


### PR DESCRIPTION
## Description
This fix is a test for this feature https://github.com/nelc/edx-platform/pull/2.

This test https://github.com/openedx/edx-platform/blob/open-release/palm.master/cms/djangoapps/contentstore/rest_api/v0/tests/test_tabs.py#L108 dont accept None value in a list sort function.

So as this is order ascending, a big value gives the same behavior



## Testing instructions

Check the tabs and they continue ordering in the desired way as the proposed in this PR https://github.com/nelc/edx-platform/pull/2 .
![2024-01-29_16-37](https://github.com/nelc/edx-platform/assets/51926076/d4adc6d4-dc1e-4fdc-9efd-482c3530f520)

## Before
Tests was failing in static tabs.
https://github.com/nelc/edx-platform/actions/runs/7702081514/job/20990641623?pr=11
![2024-01-29_16-32](https://github.com/nelc/edx-platform/assets/51926076/22122e7e-0c1a-419c-b4fd-41ff33467361)


## Other information
PRs related
https://github.com/nelc/edx-platform/pull/2
https://github.com/eduNEXT/edunext-platform/pull/678
https://github.com/eduNEXT/edunext-platform/pull/801


