### PR TITLE
feat: display tag counts on course outline page (feature flagged) (#3…

### DIFF
--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -7,6 +7,7 @@ var hasPartitionGroups = xblockInfo.get('has_partition_group_components');
 var userPartitionInfo = xblockInfo.get('user_partition_info');
 var selectedGroupsLabel = userPartitionInfo['selected_groups_label'];
 var selectedPartitionIndex = userPartitionInfo['selected_partition_index'];
+var tagsCount = (xblockInfo.get('tag_counts_by_unit') || {})[xblockInfo.get('id')] || 0;
 
 var statusMessages = [];
 var messageType;
@@ -188,11 +189,11 @@ if (is_proctored_exam) {
                     </li>
                 <% } %>
 
-                <% if (xblockInfo.isVertical() && typeof useTaggingTaxonomyListPage !== "undefined" && useTaggingTaxonomyListPage) { %>
+                <% if (xblockInfo.isVertical() && typeof useTaggingTaxonomyListPage !== "undefined" && useTaggingTaxonomyListPage && tagsCount > 0) { %>
                     <li class="action-item">
                         <a href="#" data-tooltip="<%- gettext('Manage Tags') %>" class="manage-tags-button action-button">
                             <span class="icon fa fa-tag" aria-hidden="true"></span>
-                            <span>?</span>
+                            <span><%- tagsCount %></span>
                             <span class="sr action-button-text"><%- gettext('Manage Tags') %></span>
                         </a>
                     </li>


### PR DESCRIPTION

<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description
This is a backport of  https://github.com/openedx/edx-platform/pull/33696



## Testing instructions

1. Compile styles and js files
2. check that the count of tag appears

![image](https://github.com/nelc/edx-platform/assets/36200299/e30f2991-af5b-4617-921f-591891d78f56)

