### PR TITLE
feat: Tag count in components on Studio Unit page(#33928)

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -301,6 +301,10 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
         can_edit = context.get('can_edit', True)
         # Copy-paste is a new feature; while we are beta-testing it, only beta users with the Waffle flag enabled see it
         enable_copy_paste = can_edit and ENABLE_COPY_PASTE_FEATURE.is_enabled()
+        tags_count_map = context.get('tags_count_map')
+        tags_count = 0
+        if tags_count_map:
+            tags_count = tags_count_map.get(str(xblock.location), 0)
         template_context = {
             'xblock_context': context,
             'xblock': xblock,
@@ -314,7 +318,8 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
             'selected_groups_label': selected_groups_label,
             'can_add': context.get('can_add', True),
             'can_move': context.get('can_move', xblock.scope_ids.usage_id.context_key.is_course),
-            'language': getattr(course, 'language', None)
+            'language': getattr(course, 'language', None),
+            'tags_count': tags_count,
         }
 
         add_webpack_to_fragment(frag, "js/factories/xblock_validation")

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -242,7 +242,7 @@ class GetItemTest(ItemTest):
         )
 
     @override_waffle_flag(ENABLE_TAGGING_TAXONOMY_LIST_PAGE, True)
-    @patch("cms.djangoapps.contentstore.xblock_storage_handlers.xblock_helpers.get_object_tag_counts")
+    @patch("cms.djangoapps.contentstore.views.block.get_object_tag_counts")
     def test_tag_count_in_container_fragment(self, mock_get_object_tag_counts):
         root_usage_key = self._create_vertical()
 

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -16,6 +16,7 @@ from openedx_events.content_authoring.data import DuplicatedXBlockData
 from openedx_events.content_authoring.signals import XBLOCK_DUPLICATED
 from openedx_events.tests.utils import OpenEdxEventsTestMixin
 from edx_proctoring.exceptions import ProctoredExamNotFoundException
+from edx_toggles.toggles.testutils import override_waffle_flag
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.asides import AsideUsageKeyV2
 from opaque_keys.edx.keys import CourseKey, UsageKey
@@ -69,6 +70,7 @@ from ..block import (
     add_container_page_publishing_info,
     create_xblock_info,
 )
+from cms.djangoapps.contentstore.toggles import ENABLE_TAGGING_TAXONOMY_LIST_PAGE
 
 
 class AsideTest(XBlockAside):
@@ -238,6 +240,37 @@ class GetItemTest(ItemTest):
                 re.escape(str(wrapper_usage_key))
             )
         )
+
+    @override_waffle_flag(ENABLE_TAGGING_TAXONOMY_LIST_PAGE, True)
+    @patch("cms.djangoapps.contentstore.xblock_storage_handlers.xblock_helpers.get_object_tag_counts")
+    def test_tag_count_in_container_fragment(self, mock_get_object_tag_counts):
+        root_usage_key = self._create_vertical()
+
+        # Add a problem beneath a child vertical
+        child_vertical_usage_key = self._create_vertical(
+            parent_usage_key=root_usage_key
+        )
+        resp = self.create_xblock(
+            parent_usage_key=child_vertical_usage_key,
+            category="problem",
+            boilerplate="multiplechoice.yaml",
+        )
+        self.assertEqual(resp.status_code, 200)
+        usage_key = self.response_usage_key(resp)
+
+        # Get the preview HTML without tags
+        mock_get_object_tag_counts.return_value = {}
+        html, __ = self._get_container_preview(root_usage_key)
+        self.assertIn("wrapper-xblock", html)
+        self.assertNotIn('data-testid="tag-count-button"', html)
+
+        # Get the preview HTML with tags
+        mock_get_object_tag_counts.return_value = {
+            str(usage_key): 13
+        }
+        html, __ = self._get_container_preview(root_usage_key)
+        self.assertIn("wrapper-xblock", html)
+        self.assertIn('data-testid="tag-count-button"', html)
 
     def test_split_test(self):
         """

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -24,7 +24,7 @@ function($, _, Backbone, gettext, BasePage, ViewUtils, ContainerView, XBlockView
             'click .delete-button': 'deleteXBlock',
             'click .show-actions-menu-button': 'showXBlockActionsMenu',
             'click .new-component-button': 'scrollToNewComponentButtons',
-            'click .tags-button': 'openManageTags',
+            'click .manage-tags-button': 'openManageTags',
         },
 
         options: {

--- a/cms/static/sass/partials/cms/theme/_variables-v1.scss
+++ b/cms/static/sass/partials/cms/theme/_variables-v1.scss
@@ -28,7 +28,7 @@ $fg-column: $gw-column;
 $fg-gutter: $gw-gutter;
 $fg-max-columns: 12;
 $fg-max-width: 1280px;
-$fg-min-width: 995px;
+$fg-min-width: 1005px;
 
 // +Fonts
 // ====================

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -86,6 +86,15 @@ block_is_unit = is_unit(xblock)
             <ul class="actions-list nav-dd ui-right">
                 % if not is_root:
                     % if can_edit:
+                        % if use_tagging and tags_count:
+                            <li class="action-item">
+                                <button data-tooltip="${_("Manage Tags")}" class="btn-default action-button manage-tags-button" data-testid="tag-count-button">
+                                    <span class="icon fa fa-tag" aria-hidden="true"></span>
+                                    <span>${tags_count}</span>
+                                    <span class="sr action-button-text">${_("Manage Tags")}</span>
+                                </button>
+                            </li>
+                        % endif
                         % if not show_inline:
                             <li class="action-item action-edit">
                                 <button class="btn-default edit-button action-button" data-usage-id=${xblock.scope_ids.usage_id}>
@@ -118,15 +127,6 @@ block_is_unit = is_unit(xblock)
                                         </span>
                                         <span class="sr">${_("Move")}</span>
                                     </button>
-                                </li>
-                            % endif
-                            % if use_tagging:
-                                <li class="action-item action-tag">
-                                    <a class="tags-button action-button" href="#" role="button">
-                                        <span class="icon fa fa-tag" aria-hidden="true"></span>
-                                        <span>?</span>
-                                        <span class="sr action-button-text">${_("Manage tags")}</span>
-                                    </a>
                                 </li>
                             % endif
                         % endif


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description
This is a backport of  https://github.com/openedx/edx-platform/pull/33928

## Testing instructions
1. Compile js `openedx-assets webpack --env=prod` and styles
2. Check that the tag symbol shows the number of tags

![image](https://github.com/nelc/edx-platform/assets/36200299/c2ab84ae-f9b1-41ab-b1ed-63cb6ef84457)


