### PR TITLE
fix: remove modulestore init to avoid pymongo deadlocks

### DIFF
--- a/lms/wsgi.py
+++ b/lms/wsgi.py
@@ -18,13 +18,6 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "lms.envs.aws")
 import lms.startup as startup  # lint-amnesty, pylint: disable=wrong-import-position
 startup.run()
 
-from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-position
-
-# Trigger a forced initialization of our modulestores since this can take a
-# while to complete and we want this done before HTTP requests are accepted.
-modulestore()
-
-
 # This application object is used by the development server
 # as well as any WSGI server configured to use this file.
 from django.core.wsgi import get_wsgi_application  # lint-amnesty, pylint: disable=wrong-import-order, wrong-import-position


### PR DESCRIPTION
# Description

Backport for mongo errors related serverSelectionTimeOut.
https://github.com/openedx/edx-platform/pull/34663