### PR TITLE
feat: this changes the current phone number regex to allow the plus s…

### DIFF
--- a/common/djangoapps/student/tests/test_user_profile_properties.py
+++ b/common/djangoapps/student/tests/test_user_profile_properties.py
@@ -107,23 +107,43 @@ class UserProfilePropertiesTest(CacheIsolationTestCase):
         assert cache.get(cache_key) != country
         assert cache.get(cache_key) is None
 
-    def test_phone_number_can_only_contain_digits(self):
-        # validating the profile will fail, because there are letters
-        # in the phone number
-        self.profile.phone_number = 'abc'
-        pytest.raises(ValidationError, self.profile.full_clean)
-        # fail if mixed digits/letters
-        self.profile.phone_number = '1234gb'
-        pytest.raises(ValidationError, self.profile.full_clean)
-        # fail if whitespace
-        self.profile.phone_number = '   123'
-        pytest.raises(ValidationError, self.profile.full_clean)
-        # fail with special characters
-        self.profile.phone_number = '123!@#$%^&*'
-        pytest.raises(ValidationError, self.profile.full_clean)
-        # valid phone number
-        self.profile.phone_number = '123456789'
-        try:
-            self.profile.full_clean()
-        except ValidationError:
-            self.fail("This phone number should  be valid.")
+    def test_valid_phone_numbers(self):
+        """
+        Test that valid phone numbers are accepted.
+
+        Expected behavior:
+            - The phone number '+123456789' should be considered valid.
+            - The phone number '123456789' (without '+') should also be valid.
+
+        This test verifies that valid phone numbers are accepted by the profile model validation.
+        """
+        valid_numbers = ['+123456789', '123456789']
+
+        for number in valid_numbers:
+            self.profile.phone_number = number
+
+            try:
+                self.profile.full_clean()
+            except ValidationError:
+                self.fail("This phone number should be valid.")
+
+    def test_invalid_phone_numbers(self):
+        """
+        Test that invalid phone numbers raise ValidationError.
+
+        Expected behavior:
+            - Phone numbers with letters, mixed digits/letters, whitespace,
+              or special characters should raise a ValidationError.
+
+        This test verifies that invalid phone numbers are rejected by the profile model validation.
+        """
+        invalid_phone_numbers = [
+            'abc',          # Letters in the phone number
+            '1234gb',       # Mixed digits and letters
+            '   123',       # Whitespace
+            '123!@#$%^&*'   # Special characters
+        ]
+
+        for number in invalid_phone_numbers:
+            self.profile.phone_number = number
+            pytest.raises(ValidationError, self.profile.full_clean)

--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -48,11 +48,23 @@ LOGGER = logging.getLogger(__name__)
 
 class PhoneNumberSerializer(serializers.BaseSerializer):  # lint-amnesty, pylint: disable=abstract-method
     """
-    Class to serialize phone number into a digit only representation
+    Class to serialize phone number into a digit only representation.
+
+    This serializer removes all non-numeric characters from the phone number,
+    allowing '+' only at the beginning of the number.
     """
 
     def to_internal_value(self, data):
-        """Remove all non numeric characters in phone number"""
+        """
+        Remove all non-numeric characters from the phone number.
+
+        Args:
+            data (str): The input phone number string.
+
+        Returns:
+            str or None: The cleaned phone number string containing only digits,
+                with an optional '+' at the beginning.
+        """
         return re.sub(r'(?!^)\+|[^0-9+]', "", data) or None
 
 

--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -53,7 +53,7 @@ class PhoneNumberSerializer(serializers.BaseSerializer):  # lint-amnesty, pylint
 
     def to_internal_value(self, data):
         """Remove all non numeric characters in phone number"""
-        return re.sub("[^0-9]", "", data) or None
+        return re.sub(r'(?!^)\+|[^0-9+]', "", data) or None
 
 
 class LanguageProficiencySerializer(serializers.ModelSerializer):


### PR DESCRIPTION

## Description

This modifies the current serializer regex that removes all characters that are not numbers, to allow the plus symbol at the beginning.


## Testing instructions

```python
import re

data = "+57+26100*4-8"
re.sub(r'(?!^)\+|[^0-9+]', "", data) # Expected result  "+572610048"
```

