### PR TITLE
feat: remove staff access in courses for catalog views

### DIFF
--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -394,6 +394,10 @@ def _has_access_course(user, action, courselike):
         """
         return (
             _has_catalog_visibility(courselike, CATALOG_VISIBILITY_CATALOG_AND_ABOUT)
+            or (
+                _has_staff_access_to_descriptor(user, courselike, courselike.id)
+                and getattr(settings, "STAFF_CAN_SEE_IN_CATALOG", False)
+            )
         )
 
     @function_trace('can_see_about_page')

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -394,7 +394,6 @@ def _has_access_course(user, action, courselike):
         """
         return (
             _has_catalog_visibility(courselike, CATALOG_VISIBILITY_CATALOG_AND_ABOUT)
-            or _has_staff_access_to_descriptor(user, courselike, courselike.id)
         )
 
     @function_trace('can_see_about_page')

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -396,7 +396,7 @@ def _has_access_course(user, action, courselike):
             _has_catalog_visibility(courselike, CATALOG_VISIBILITY_CATALOG_AND_ABOUT)
             or (
                 _has_staff_access_to_descriptor(user, courselike, courselike.id)
-                and getattr(settings, "STAFF_CAN_SEE_IN_CATALOG", False)
+                and getattr(settings, "STAFF_CAN_SEE_IN_CATALOG", True)
             )
         )
 

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -611,7 +611,7 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         )
         assert not access._has_access_course(user, 'see_in_catalog', course)
         assert access._has_access_course(user, 'see_about_page', course)
-        assert not access._has_access_course(staff, 'see_in_catalog', course)
+        assert access._has_access_course(staff, 'see_in_catalog', course)
         assert access._has_access_course(staff, 'see_about_page', course)
 
         # Now set visibility to none, which means neither in catalog nor about pages
@@ -621,7 +621,7 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         )
         assert not access._has_access_course(user, 'see_in_catalog', course)
         assert not access._has_access_course(user, 'see_about_page', course)
-        assert not access._has_access_course(staff, 'see_in_catalog', course)
+        assert access._has_access_course(staff, 'see_in_catalog', course)
         assert access._has_access_course(staff, 'see_about_page', course)
 
     @patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True, 'MILESTONES_APP': True})

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -611,7 +611,7 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         )
         assert not access._has_access_course(user, 'see_in_catalog', course)
         assert access._has_access_course(user, 'see_about_page', course)
-        assert access._has_access_course(staff, 'see_in_catalog', course)
+        assert not access._has_access_course(staff, 'see_in_catalog', course)
         assert access._has_access_course(staff, 'see_about_page', course)
 
         # Now set visibility to none, which means neither in catalog nor about pages
@@ -621,7 +621,7 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         )
         assert not access._has_access_course(user, 'see_in_catalog', course)
         assert not access._has_access_course(user, 'see_about_page', course)
-        assert access._has_access_course(staff, 'see_in_catalog', course)
+        assert not access._has_access_course(staff, 'see_in_catalog', course)
         assert access._has_access_course(staff, 'see_about_page', course)
 
     @patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True, 'MILESTONES_APP': True})


### PR DESCRIPTION


<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This is controversial, but simple. To do this in custom eox-nelp with  a monkey patch is a bigger task and also with more work and risk. Is different due the change is in a nested function. Anyway the alternative is to monkeyPatch the `_dispatch` method and handle there. But its risky and also that method manage other permission with different ways.


## Testing instructions
HIde a course in studio and check that for anonymous_user doesn't load but for staff general yes.
![before_1](https://github.com/user-attachments/assets/508d902d-d83b-4cbc-86e2-e5e806409782)

### Before
staff
![before_1](https://github.com/user-attachments/assets/5d56d115-7fb0-4d98-a1aa-c8fa73f7d9c9)
anonymous_user
![before_2](https://github.com/user-attachments/assets/9e2b5030-9402-4144-9ff3-ec1c3ae0ca90)


### After 
staff
![after_1](https://github.com/user-attachments/assets/e792fefe-a19c-420e-b293-a8466715ca0d)
anonymous_user
![after_2](https://github.com/user-attachments/assets/b98d7d1c-6442-4ec2-99c2-7ab6d7c02a05)



## Other information

**[Jira Story](https://edunext.atlassian.net/browse/FUTUREX-859?atlOrigin=eyJpIjoiMDViZGZmYmRhODExNDk3NDhiMmFiZGZlOTYzYzBmNWEiLCJwIjoiaiJ9)**: 