### PR TITLE
feat: control linked account by settings 

### DIFF
--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -15,6 +15,7 @@
         return function(
             fieldsData,
             disableOrderHistoryTab,
+            showLinkedAccountsTab,
             ordersHistoryData,
             authData,
             passwordResetSupportUrl,
@@ -442,6 +443,7 @@
                 },
                 userPreferencesModel: userPreferencesModel,
                 disableOrderHistoryTab: disableOrderHistoryTab,
+                showLinkedAccountsTab: showLinkedAccountsTab,
                 betaLanguage: betaLanguage
             });
 

--- a/lms/static/js/student_account/views/account_settings_view.js
+++ b/lms/static/js/student_account/views/account_settings_view.js
@@ -39,15 +39,18 @@
                         selected: true,
                         expanded: true
                     },
-                    {
+                ];
+
+                if (view.options.showLinkedAccountsTab) {
+                    accountSettingsTabs.push({
                         name: 'accountsTabSections',
                         id: 'accounts-tab',
                         label: gettext('Linked Accounts'),
                         tabindex: -1,
                         selected: false,
                         expanded: false
-                    }
-                ];
+                    });
+                }
                 if (!view.options.disableOrderHistoryTab) {
                     accountSettingsTabs.push({
                         name: 'ordersTabSections',

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -53,6 +53,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
     AccountSettingsFactory(
         fieldsData,
         ${ disable_order_history_tab | n, dump_js_escaped_json },
+        ${ show_linked_accounts_tab | n, dump_js_escaped_json },
         ordersHistoryData,
         authData,
         '${ password_reset_support_link | n, js_escaped_string }',

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -30,7 +30,8 @@ from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api.accounts.toggles import (
     should_redirect_to_account_microfrontend,
-    should_redirect_to_order_history_microfrontend
+    should_redirect_to_order_history_microfrontend,
+    should_show_linked_accounts_tab
 )
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preferences
 from openedx.core.lib.edx_api_utils import get_api_data
@@ -159,6 +160,7 @@ def account_settings_context(request):
         'show_dashboard_tabs': True,
         'order_history': user_orders,
         'disable_order_history_tab': should_redirect_to_order_history_microfrontend(),
+        'show_linked_accounts_tab': should_show_linked_accounts_tab(),
         'enable_account_deletion': configuration_helpers.get_value(
             'ENABLE_ACCOUNT_DELETION', settings.FEATURES.get('ENABLE_ACCOUNT_DELETION', False)
         ),

--- a/openedx/core/djangoapps/user_api/accounts/toggles.py
+++ b/openedx/core/djangoapps/user_api/accounts/toggles.py
@@ -26,6 +26,13 @@ def should_redirect_to_order_history_microfrontend():
     )
 
 
+def should_show_linked_accounts_tab():
+    """Check if the the var `SHOW_LINKED_ACCOUNTS`
+        is defined in configuration helpers.
+    """
+    return configuration_helpers.get_value('SHOW_LINKED_ACCOUNTS', True)
+
+
 # .. toggle_name: account.redirect_to_microfrontend
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False

--- a/openedx/core/djangoapps/user_api/accounts/toggles.py
+++ b/openedx/core/djangoapps/user_api/accounts/toggles.py
@@ -1,9 +1,8 @@
 """
 Toggles for accounts related code.
 """
-
+from django.conf import settings
 from edx_toggles.toggles import WaffleFlag
-
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 # .. toggle_name: order_history.redirect_to_microfrontend
@@ -30,7 +29,7 @@ def should_show_linked_accounts_tab():
     """Check if the the var `SHOW_LINKED_ACCOUNTS`
         is defined in configuration helpers.
     """
-    return configuration_helpers.get_value('SHOW_LINKED_ACCOUNTS', True)
+    return getattr(settings, 'SHOW_LINKED_ACCOUNTS', True)
 
 
 # .. toggle_name: account.redirect_to_microfrontend


### PR DESCRIPTION
## Description

Migration pr of https://github.com/nelc/edx-platform/pull/3 [issue](https://edunext.atlassian.net/browse/FUTUREX-959)

## Testing instructions

1. deactivate mfes set the following flags to everyone = No
![image](https://github.com/user-attachments/assets/01846e8d-6f56-47b4-a9bd-92a71ae3b697)
2. Go to the account page `http://local.overhang.io:8000/account/settings`
3. set the SHOW_LINKED_ACCOUNTS  to True or False based on the behavior that you want, true show the linked account section, False hides the linked account section

### Result with SHOW_LINKED_ACCOUNTS = True
![image](https://github.com/user-attachments/assets/19819e04-33d5-4885-99c1-7cf531cd2f4e)

### Result with SHOW_LINKED_ACCOUNTS = False
![image](https://github.com/user-attachments/assets/17f2239f-0b52-4d13-b4b9-2f5f017deacf)
