### PR TITLE
feat: Add setting DISABLE_ORDER_HISTORY_TAB 

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -159,7 +159,7 @@ def account_settings_context(request):
         'show_dashboard_tabs': True,
         'order_history': user_orders,
         'disable_order_history_tab': (
-            configuration_helpers.get_value('DISABLE_ORDER_HISTORY_TAB', False)
+            getattr(settings, 'DISABLE_ORDER_HISTORY_TAB', False)
             or should_redirect_to_order_history_microfrontend()
         ),
         'enable_account_deletion': configuration_helpers.get_value(

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -158,7 +158,10 @@ def account_settings_context(request):
         'show_program_listing': ProgramsApiConfig.is_enabled(),
         'show_dashboard_tabs': True,
         'order_history': user_orders,
-        'disable_order_history_tab': should_redirect_to_order_history_microfrontend(),
+        'disable_order_history_tab': (
+            configuration_helpers.get_value('DISABLE_ORDER_HISTORY_TAB', False)
+            or should_redirect_to_order_history_microfrontend()
+        ),
         'enable_account_deletion': configuration_helpers.get_value(
             'ENABLE_ACCOUNT_DELETION', settings.FEATURES.get('ENABLE_ACCOUNT_DELETION', False)
         ),


### PR DESCRIPTION
## Description

Migration pr of https://github.com/nelc/edx-platform/pull/8 [issue](https://edunext.atlassian.net/browse/FUTUREX-959)

## Testing instructions

## Testing instructions

1. Deactivate mfes set the following flags to everyone = No
![image](https://github.com/user-attachments/assets/01846e8d-6f56-47b4-a9bd-92a71ae3b697)
2. Go to the account page `http://local.overhang.io:8000/account/settings`
3. set the DISABLE_ORDER_HISTORY_TAB  to True or False based on the behavior that you want, true  hides the order section, False shows the order section

### Result with DISABLE_ORDER_HISTORY_TAB = True
![image](https://github.com/user-attachments/assets/41424540-807e-44d6-9c8e-a783fdb7a50d)

### Result with DISABLE_ORDER_HISTORY_TAB = False
![image](https://github.com/user-attachments/assets/3b7c6411-3ce6-49b8-8490-3b986b28851a)


