### PR TITLE
feat: add course type field to advanced settings and course info index

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -589,6 +589,7 @@ class CourseAboutSearchIndexer(CoursewareSearchIndexer):
         AboutInfo("language", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("invitation_only", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("catalog_visibility", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
+        AboutInfo("course_type", AboutInfo.ANALYSE | AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
     ]
 
     @classmethod

--- a/xmodule/course_block.py
+++ b/xmodule/course_block.py
@@ -1059,6 +1059,15 @@ class CourseFields:  # lint-amnesty, pylint: disable=missing-class-docstring
         scope=Scope.settings
     )
 
+    course_type = String(
+        display_name=_("Course Type"),
+        help=_(
+            "Content type that helps the student to filter courses which are more interesting for them."
+        ),
+        default=None,
+        scope=Scope.settings,
+    )
+
 
 class CourseBlock(
     CourseFields,


### PR DESCRIPTION
## Description

Migration pr of https://github.com/nelc/edx-platform/pull/7 [issue](https://edunext.atlassian.net/browse/FUTUREX-959) 


## Testing instructions

1. Disable mfes
![image](https://github.com/user-attachments/assets/e461f2fa-ec4f-4551-9d16-651132656517)

2. Go to the advanced setting section
![image](https://github.com/user-attachments/assets/695752cd-82d1-4919-81e2-268590a7c31f)

3. Check the course type field
![image](https://github.com/user-attachments/assets/1d08c9e8-c693-4876-8739-d2a5efd69ce7)


