### PR TITLE
feat: filter by current site organizations

### DIFF
--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -36,6 +36,7 @@ from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.courseware.views.index import save_positions_recursively_up
 from lms.djangoapps.mobile_api.models import MobileConfig
 from lms.djangoapps.mobile_api.utils import API_V1, API_V05, API_V2, API_V3, API_V4
+from openedx.core.djangoapps.site_configuration.helpers import get_current_site_orgs
 from openedx.features.course_duration_limits.access import check_course_expired
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
@@ -346,6 +347,11 @@ class UserCourseEnrollmentsList(generics.ListAPIView):
         """
         Check course org matches request org param or no param provided
         """
+        current_orgs = get_current_site_orgs()
+
+        if current_orgs and course_org not in current_orgs:
+            return False
+
         return check_org is None or (check_org.lower() == course_org.lower())
 
     def get_serializer_context(self):


### PR DESCRIPTION
## Description

Migration pr of https://github.com/nelc/edx-platform/pull/36 [issue](https://edunext.atlassian.net/browse/FUTUREX-959)

## Testing instructions

1. Go to `/api/mobile/v4/users/<username>/course_enrollments/ ` and check that the result doesn't contain any invalid organization 


