### PR TITLE
feat: allow to include translations for extended profile fields

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -28,6 +28,7 @@ from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.djangoapps.lang_pref.api import all_languages, released_languages
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.theming import helpers as theming_helpers
 from openedx.core.djangoapps.user_api.accounts.toggles import (
     should_redirect_to_account_microfrontend,
     should_redirect_to_order_history_microfrontend,
@@ -276,6 +277,15 @@ def _get_extended_profile_fields():
         "specialty": _("Specialty"),
         "work_experience": _("Work experience")
     }
+    request = theming_helpers.get_current_request()
+
+    if request:
+        extended_profile_fields_translations = configuration_helpers.get_value(
+            'extended_profile_fields_translations',
+            {},
+        )
+        translations = extended_profile_fields_translations.get(request.LANGUAGE_CODE, {})
+        field_labels_map.update(translations)
 
     extended_profile_field_names = configuration_helpers.get_value('extended_profile_fields', [])
     for field_to_exclude in fields_already_showing:


### PR DESCRIPTION


<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Migration pr of https://github.com/nelc/edx-platform/pull/10   [issue ](https://edunext.atlassian.net/browse/FUTUREX-959)

(cherry picked from 5ad0e35547ce263c879882a726365b3243b9c272 and 4d24257f741672b6936d6774061ea7aa4ffa0071 )

### How to test
Follow the instruction of the original [pr](https://github.com/nelc/edx-platform/pull/10) 

## Result
![image](https://github.com/user-attachments/assets/00430ab5-e00a-4930-a5a3-67b103ae5c81)

