### PR TITLE
feat: move progress related apis permissions to standard permission file

### DIFF
--- a/lms/djangoapps/course_home_api/permissions.py
+++ b/lms/djangoapps/course_home_api/permissions.py
@@ -1,0 +1,10 @@
+"""
+Permissions for the course home apis and associated actions
+"""
+from bridgekeeper import perms
+from lms.djangoapps.courseware.rules import HasAccessRule
+
+
+CAN_MASQUARADE_LEARNER_PROGRESS = 'course_home_api.can_masquarade_progress'
+
+perms[CAN_MASQUARADE_LEARNER_PROGRESS] = HasAccessRule('staff')

--- a/lms/djangoapps/course_home_api/progress/views.py
+++ b/lms/djangoapps/course_home_api/progress/views.py
@@ -14,6 +14,7 @@ from rest_framework.response import Response
 
 from xmodule.modulestore.django import modulestore
 from common.djangoapps.student.models import CourseEnrollment
+from lms.djangoapps.course_home_api import permissions
 from lms.djangoapps.course_home_api.progress.serializers import ProgressTabSerializer
 from lms.djangoapps.course_home_api.toggles import course_home_mfe_progress_tab_is_active
 from lms.djangoapps.courseware.access import has_access, has_ccx_coach_role
@@ -186,8 +187,9 @@ class ProgressTabView(RetrieveAPIView):
         monitoring_utils.set_custom_attribute('user_id', request.user.id)
         monitoring_utils.set_custom_attribute('is_staff', request.user.is_staff)
         is_staff = bool(has_access(request.user, 'staff', course_key))
+        can_masquarade = request.user.has_perm(permissions.CAN_MASQUARADE_LEARNER_PROGRESS, course_key)
 
-        student = self._get_student_user(request, course_key, student_id, is_staff)
+        student = self._get_student_user(request, course_key, student_id, can_masquarade)
         username = get_enterprise_learner_generic_name(request) or student.username
 
         course = get_course_with_access(student, 'load', course_key, check_if_enrolled=False)
@@ -196,7 +198,7 @@ class ProgressTabView(RetrieveAPIView):
         enrollment = CourseEnrollment.get_enrollment(student, course_key)
         enrollment_mode = getattr(enrollment, 'mode', None)
 
-        if not (enrollment and enrollment.is_active) and not is_staff:
+        if not (enrollment and enrollment.is_active) and not can_masquarade:
             return Response('User not enrolled.', status=401)
 
         # The block structure is used for both the course_grade and has_scheduled content fields

--- a/lms/djangoapps/course_home_api/tests/test_permissions.py
+++ b/lms/djangoapps/course_home_api/tests/test_permissions.py
@@ -1,0 +1,70 @@
+"""
+Tests for permissions defined in courseware.rules
+"""
+import ddt
+
+from common.djangoapps.student.roles import OrgStaffRole, CourseStaffRole
+from common.djangoapps.student.tests.factories import UserFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from lms.djangoapps.course_home_api.permissions import CAN_MASQUARADE_LEARNER_PROGRESS
+
+
+@ddt.ddt
+class PermissionTests(ModuleStoreTestCase):
+    """
+    Tests for permissions defined in courseware.rules
+    """
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+        self.course = CourseFactory(org='org')
+        self.another_course = CourseFactory(org='org')
+
+    def tearDown(self):
+        super().tearDown()
+        self.user.delete()
+
+    @ddt.data(
+        (
+            True, None, None, True,
+            "Global staff users should have masquerade access",
+        ),
+        (
+            False, None, None, False,
+            "Non-staff users shouldn't have masquerade access",
+        ),
+        (
+            False, 'another_org', None, False,
+            "User with staff access on another org shouldn't have masquerade access",
+        ),
+        (
+            False, 'org', None, True,
+            "User with org-wide staff access should have masquerade access",
+        ),
+        (
+            False, None, 'another_course', False,
+            "User with staff access on another course shouldn't have masquerade access",
+        ),
+        (
+            False, None, 'course', True,
+            "User with staff access on the course should have masquerade access",
+        ),
+    )
+    @ddt.unpack
+    def test_can_masquerade_return_value(self, is_staff, org_role, course_role, expected_permission, description):
+        """
+        Test that only authorized users have masquerade access
+        """
+        self.user.is_staff = is_staff
+        self.user.save()
+        assert self.user.is_staff == is_staff
+
+        if org_role:
+            OrgStaffRole(org_role).add_users(self.user)
+
+        if course_role:
+            CourseStaffRole(getattr(self, course_role).id).add_users(self.user)
+
+        has_perm = self.user.has_perm(CAN_MASQUARADE_LEARNER_PROGRESS, self.course.id)
+        assert has_perm == expected_permission, description


### PR DESCRIPTION

## Description

feat: move progress related apis permissions to standard permission file so it can be override for data researchers.

## Supporting information

Related Issue: [feat: Data Researcher to have access on course progress page of Students](https://github.com/nelc/futurex-openedx-extensions/issues/151)
