### PR TITLE
feat: move progress related apis permissions to standard permission file

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/views.py
@@ -19,6 +19,7 @@ from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.course_api.api import course_detail
 from lms.djangoapps.course_goals.models import UserActivity
+from lms.djangoapps.course_home_api import permissions
 from lms.djangoapps.course_home_api.course_metadata.serializers import CourseHomeMetadataSerializer
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.context_processor import user_timezone_locale_prefs
@@ -81,9 +82,8 @@ class CourseHomeMetadataView(RetrieveAPIView):
         course_key = CourseKey.from_string(course_key_string)
         original_user_is_global_staff = self.request.user.is_staff
         original_user_is_staff = has_access(request.user, 'staff', course_key).has_access
-
+        user_can_masquarade = request.user.has_perm(permissions.CAN_MASQUARADE_LEARNER_PROGRESS, course_key)
         course = course_detail(request, request.user.username, course_key)
-
         # We must compute course load access *before* setting up masquerading,
         # else course staff (who are not enrolled) will not be able view
         # their course from the perspective of a learner.
@@ -91,7 +91,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
             course,
             request.user,
             'load',
-            check_if_enrolled=True,
+            check_if_enrolled=(not user_can_masquarade),
             check_if_authenticated=True,
             apply_enterprise_checks=True,
         )
@@ -99,7 +99,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
         _, request.user = setup_masquerade(
             request,
             course_key,
-            staff_access=original_user_is_staff,
+            staff_access=user_can_masquarade,
             reset_masquerade_data=True,
         )
 

--- a/lms/djangoapps/course_home_api/permissions.py
+++ b/lms/djangoapps/course_home_api/permissions.py
@@ -1,0 +1,10 @@
+"""
+Permissions for the course home apis and associated actions
+"""
+from bridgekeeper import perms
+from lms.djangoapps.courseware.rules import HasAccessRule
+
+
+CAN_MASQUARADE_LEARNER_PROGRESS = 'course_home_api.can_masquarade_progress'
+
+perms[CAN_MASQUARADE_LEARNER_PROGRESS] = HasAccessRule('staff')

--- a/lms/djangoapps/course_home_api/tests/test_permissions.py
+++ b/lms/djangoapps/course_home_api/tests/test_permissions.py
@@ -1,0 +1,70 @@
+"""
+Tests for permissions defined in courseware.rules
+"""
+import ddt
+
+from common.djangoapps.student.roles import OrgStaffRole, CourseStaffRole
+from common.djangoapps.student.tests.factories import UserFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
+from lms.djangoapps.course_home_api.permissions import CAN_MASQUARADE_LEARNER_PROGRESS
+
+
+@ddt.ddt
+class PermissionTests(ModuleStoreTestCase):
+    """
+    Tests for permissions defined in courseware.rules
+    """
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+        self.course = CourseFactory(org='org')
+        self.another_course = CourseFactory(org='org')
+
+    def tearDown(self):
+        super().tearDown()
+        self.user.delete()
+
+    @ddt.data(
+        (
+            True, None, None, True,
+            "Global staff users should have masquerade access",
+        ),
+        (
+            False, None, None, False,
+            "Non-staff users shouldn't have masquerade access",
+        ),
+        (
+            False, 'another_org', None, False,
+            "User with staff access on another org shouldn't have masquerade access",
+        ),
+        (
+            False, 'org', None, True,
+            "User with org-wide staff access should have masquerade access",
+        ),
+        (
+            False, None, 'another_course', False,
+            "User with staff access on another course shouldn't have masquerade access",
+        ),
+        (
+            False, None, 'course', True,
+            "User with staff access on the course should have masquerade access",
+        ),
+    )
+    @ddt.unpack
+    def test_can_masquerade_return_value(self, is_staff, org_role, course_role, expected_permission, description):
+        """
+        Test that only authorized users have masquerade access
+        """
+        self.user.is_staff = is_staff
+        self.user.save()
+        assert self.user.is_staff == is_staff
+
+        if org_role:
+            OrgStaffRole(org_role).add_users(self.user)
+
+        if course_role:
+            CourseStaffRole(getattr(self, course_role).id).add_users(self.user)
+
+        has_perm = self.user.has_perm(CAN_MASQUARADE_LEARNER_PROGRESS, self.course.id)
+        assert has_perm == expected_permission, description


### PR DESCRIPTION
## Description

feat: move progress related apis permissions to standard permission file so it can be override for data researchers.

## Supporting information

Related Issue: [feat: Data Researcher to have access on course progress page of Students](https://github.com/nelc/futurex-openedx-extensions/issues/151)

Related PR for palm: https://github.com/nelc/edx-platform/pull/51