### PR TITLE
fix: roles cache organization case-insensitive

### DIFF
--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -167,7 +167,7 @@ class RoleCache:
         course_id_string = get_role_cache_key_for_course(course_id)
         course_roles = self._roles_by_course_id.get(course_id_string, [])
         return any(
-            access_role.role in self.get_roles(role) and access_role.org == org
+            access_role.role in self.get_roles(role) and access_role.org.lower() == org.lower()
             for access_role in course_roles
         )
 

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -232,6 +232,17 @@ class RoleCacheTestCase(TestCase):  # lint-amnesty, pylint: disable=missing-clas
             else:
                 assert not cache.has_role(*other_target)
 
+    @ddt.data(IN_KEY.org, 'edx', 'EDX', 'EdX')
+    def test_org_case_insensitive(self, compare_to_org):
+        org_role = OrgStaffRole(self.IN_KEY.org)
+        course_role = CourseInstructorRole(self.IN_KEY)
+        org_role.add_users(self.user)
+        course_role.add_users(self.user)
+
+        role_cache = RoleCache(self.user)
+        assert role_cache.has_role('staff', None, compare_to_org)
+        assert role_cache.has_role('instructor', self.IN_KEY, compare_to_org)
+
     @ddt.data(*ROLES)
     @ddt.unpack
     def test_empty_cache(self, role, target):  # lint-amnesty, pylint: disable=unused-argument


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

`RoleCache` compares `org` in a case-sensitive manner while the value of `org` is assumed as case-insensitive by the database collation, and by the [django admin form](https://github.com/openedx/edx-platform/blob/059f8338045c4465cd2086403069d5521c773e18/common/djangoapps/student/admin.py#L154). This PR is to fix the issue to make `RoleCache` behave as the rest of the platform

## Supporting information

*

## Testing instructions

**Preperation to test:**
* Assume a normal user in the platform, for example `test_user`
* Assuming we have two courses in `demo` organization: `course-v1:Demo+topic1+index1` and `course-v1:demo+topic2+index2`. We have the first course with organization `Demo` in course-overview instead of `demo`. This is acceptable in the platform

**Before the fix:**
* The admin will not be able to grant `test_user` an `instructor` on the entire `demo` organization, the admin will have to grant it course by course. This is because `CourseAccessRole` will not allow two similar records like `[user: test_user, course_id: "", role: instructor, org: demo]` and `[user: test_user, course_id: "", role: instructor, org: Demo]`. The key constraint treats `org` as case-insensitive

**After the fix:**
* Adding a single record like `[user: test_user, course_id: "", role: instructor, org: demo]`, `[user: test_user, course_id: "", role: instructor, org: Demo]`, or even `[user: test_user, course_id: "", role: instructor, org: DEMO]` will make `test_user` an instructor on all courses as expected

## Deadline

*

## Other information

* This is an upstream issue. We'll contribute the fix to upstream once we have a code review here
