### PR TITLE
fix: implement __repr__ method in order to avoid maximum recursion error

### DIFF
--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -288,13 +288,14 @@ class StudentModuleHistory(BaseStudentModuleHistory):
     student_module = models.ForeignKey(StudentModule, db_index=True, db_constraint=False, on_delete=models.CASCADE)
 
     def __repr__(self):
-        return "StudentModuleHistory<{!r}>".format(
-            {
-                "course_id": str(self.student_module.course_id),
-                "module_type": self.student_module.module_type,
-                "student_id": self.student_module.student_id,
-                "grade": self.grade,
-            })
+        student_dict = {
+            "course_id": str(self.student_module.course_id),
+            "module_type": self.student_module.module_type,
+            "student_id": self.student_module.student_id,
+            "grade": self.grade,
+        }
+
+        return f"StudentModuleHistory<{student_dict!r}>"
 
     def __str__(self):
         return str(repr(self))


### PR DESCRIPTION
## Description

This is a fix/feature since implements a new model representation for StudentModuleHistory and fixes the recursion error  that is generated by this [line](https://github.com/nelc/edx-platform/blob/open-release/redwood.nelp/lms/djangoapps/courseware/models.py#L291)


## Testing instructions

1. Get into the lms docker container `docker exec -it tutor_dev-lms-1 bash`
2. Open a shell `./manage.py lms shell`
3.  Run the following code, ensure that you have at least one record

```python
from lms.djangoapps.courseware.models import StudentModuleHistory

StudentModuleHistory.objects.all()[:10]
```

