### PR TITLE
feat: add course type field to advanced settings and course info index

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -590,6 +590,7 @@ class CourseAboutSearchIndexer(CoursewareSearchIndexer):
         AboutInfo("language", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("invitation_only", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("catalog_visibility", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
+        AboutInfo("course_type", AboutInfo.ANALYSE | AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
     ]
 
     @classmethod

--- a/xmodule/course_block.py
+++ b/xmodule/course_block.py
@@ -1062,6 +1062,15 @@ class CourseFields:  # lint-amnesty, pylint: disable=missing-class-docstring
         scope=Scope.settings
     )
 
+    course_type = String(
+        display_name=_("Course Type"),
+        help=_(
+            "Content type that helps the student to filter courses which are more interesting for them."
+        ),
+        default=None,
+        scope=Scope.settings,
+    )
+
 
 class CourseBlock(
     CourseFields,


### PR DESCRIPTION
(cherry picked from commit 8697c96e23d0384a6a44b098e965980be3b50b73) (cherry picked from commit 0976ffbb17dfe2f110dcd585545ab5e3a048b0a5)



## Description

(cherry picked from commit 8697c96e23d0384a6a44b098e965980be3b50b73) (cherry picked from commit 0976ffbb17dfe2f110dcd585545ab5e3a048b0a5)


### How to test

1. Go to the advanced setting section and check course Type option. (course authoring)
Fill it and save

[Screencast from 29-09-25 15:55:33.webm](https://github.com/user-attachments/assets/bc50a488-22f3-41b8-a673-7ec51e6224ac)


2. Check in mongo the data was saved (Optional)

```db.modulestore.structures.find().sort({ edited_on: -1 }).limit(3)```

<img width="956" height="958" alt="2025-09-29_15-59" src="https://github.com/user-attachments/assets/813c02e6-ef4b-4979-a993-b6325b531929" />


** Jira story**:
https://edunext.atlassian.net/browse/FUTUREX-1300
