### PR TITLE
fix: roles cache organization case-insensitive

### DIFF
--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -167,7 +167,7 @@ class RoleCache:
         course_id_string = get_role_cache_key_for_course(course_id)
         course_roles = self._roles_by_course_id.get(course_id_string, [])
         return any(
-            access_role.role in self.get_roles(role) and access_role.org == org
+            access_role.role in self.get_roles(role) and access_role.org.lower() == org.lower()
             for access_role in course_roles
         )
 

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -232,6 +232,17 @@ class RoleCacheTestCase(TestCase):  # lint-amnesty, pylint: disable=missing-clas
             else:
                 assert not cache.has_role(*other_target)
 
+    @ddt.data(IN_KEY.org, 'edx', 'EDX', 'EdX')
+    def test_org_case_insensitive(self, compare_to_org):
+        org_role = OrgStaffRole(self.IN_KEY.org)
+        course_role = CourseInstructorRole(self.IN_KEY)
+        org_role.add_users(self.user)
+        course_role.add_users(self.user)
+
+        role_cache = RoleCache(self.user)
+        assert role_cache.has_role('staff', None, compare_to_org)
+        assert role_cache.has_role('instructor', self.IN_KEY, compare_to_org)
+
     @ddt.data(*ROLES)
     @ddt.unpack
     def test_empty_cache(self, role, target):  # lint-amnesty, pylint: disable=unused-argument


### PR DESCRIPTION

<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

(cherry picked from commit 4de5d0e85a64c4f8f1d42f5793a7b1191e020727)


Migration PR to teak from the logic added in https://github.com/nelc/edx-platform/pull/53

## Supporting information
** Jira story**:  https://edunext.atlassian.net/browse/FUTUREX-1260
