### PR TITLE
feat: disable order history from user dropdown

### DIFF
--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -23,7 +23,7 @@ displayname = get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.
-should_show_order_history = not enterprise_customer_portal
+should_show_order_history = getattr(settings, 'DISABLE_ORDER_HISTORY_TAB', False) and not enterprise_customer_portal
 %>
 
 <div class="nav-item hidden-mobile">


### PR DESCRIPTION
# Description

Migration PR

Due to the removal of legacy accounts, some changes were introduced. The order history is no longer managed in the account frontend, but it's still available in the user_dropdown.
https://github.com/openedx/edx-platform/pull/36219/files#diff-ee7c5052643d6a3419accc236c5db246cd08f4a9990191c25de57b4df660f3c5R26


This adds the setting of the past PR  https://github.com/nelc/edx-platform/pull/40 to manage the order history in the user dropdown.


### Before

<img width="1901" height="860" alt="2025-10-02_17-54" src="https://github.com/user-attachments/assets/aebd2de7-bb10-4985-af08-4dd7e36222a7" />



### After

<img width="1908" height="852" alt="2025-10-02_18-00" src="https://github.com/user-attachments/assets/bff55577-5ff2-4311-94a9-efd6af76c823" />

**Jira story**:  https://edunext.atlassian.net/browse/FUTUREX-1301


