### PR TITLE
Crls/restore user

### DIFF
--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -234,8 +234,6 @@ def is_email_retired(email):
     This enables users to re-register with the same email after account retirement.
     The new registration will be a completely separate account with no previous data.
     """
-    log.info(f"Checking if email {email} is retired")
-    print(f"Checking if email {email} is retired")
     # Allow retired emails to be reused
     return False
 

--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -210,7 +210,7 @@ def user_by_anonymous_id(uid):
 def is_username_retired(username):
     """
     Checks to see if the given username has been previously retired
-    
+
     Modified to allow retired usernames to be reused for new registrations.
     This enables users to re-register with the same username after account retirement.
     The new registration will be a completely separate account with no previous data.
@@ -229,7 +229,7 @@ def username_exists_or_retired(username):
 def is_email_retired(email):
     """
     Checks to see if the given email has been previously retired
-    
+
     Modified to allow retired emails to be reused for new registrations.
     This enables users to re-register with the same email after account retirement.
     The new registration will be a completely separate account with no previous data.

--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -210,31 +210,13 @@ def user_by_anonymous_id(uid):
 def is_username_retired(username):
     """
     Checks to see if the given username has been previously retired
+    
+    Modified to allow retired usernames to be reused for new registrations.
+    This enables users to re-register with the same username after account retirement.
+    The new registration will be a completely separate account with no previous data.
     """
-    locally_hashed_usernames = user_util.get_all_retired_usernames(
-        username,
-        settings.RETIRED_USER_SALTS,
-        settings.RETIRED_USERNAME_FMT
-    )
-
-    # TODO: Revert to this after username capitalization issues detailed in
-    # PLAT-2276, PLAT-2277, PLAT-2278 are sorted out:
-    # return User.objects.filter(username__in=list(locally_hashed_usernames)).exists()
-
-    # Avoid circular import issues
-    from openedx.core.djangoapps.user_api.models import UserRetirementStatus
-
-    # Sandbox clean builds attempt to create users during migrations, before the database
-    # is stable so UserRetirementStatus may not exist yet. This workaround can also go
-    # when we are done with the username updates.
-    try:
-        return User.objects.filter(username__in=list(locally_hashed_usernames)).exists() or \
-            UserRetirementStatus.objects.filter(original_username=username).exists()
-    except ProgrammingError as exc:
-        # Check the error message to make sure it's what we expect
-        if "user_api_userretirementstatus" in str(exc):
-            return User.objects.filter(username__in=list(locally_hashed_usernames)).exists()
-        raise
+    # Allow retired usernames to be reused
+    return False
 
 
 def username_exists_or_retired(username):
@@ -247,14 +229,15 @@ def username_exists_or_retired(username):
 def is_email_retired(email):
     """
     Checks to see if the given email has been previously retired
+    
+    Modified to allow retired emails to be reused for new registrations.
+    This enables users to re-register with the same email after account retirement.
+    The new registration will be a completely separate account with no previous data.
     """
-    locally_hashed_emails = user_util.get_all_retired_emails(
-        email,
-        settings.RETIRED_USER_SALTS,
-        settings.RETIRED_EMAIL_FMT
-    )
-
-    return User.objects.filter(email__in=list(locally_hashed_emails)).exists()
+    log.info(f"Checking if email {email} is retired")
+    print(f"Checking if email {email} is retired")
+    # Allow retired emails to be reused
+    return False
 
 
 def email_exists_or_retired(email):

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -200,7 +200,7 @@ def create_retirement_request_and_deactivate_account(user):
     """
     Adds user to retirement queue, unlinks social auth accounts, changes user passwords
     and delete tokens and activation keys
-    
+
     Modified to include user ID in retired credentials to allow reuse of original credentials.
     """
     # Add user to retirement queue.
@@ -213,7 +213,7 @@ def create_retirement_request_and_deactivate_account(user):
     # Include user ID to ensure uniqueness when retired credentials are reused
     retired_username = f"retired__user_{user.id}_{user.username}"
     retired_email = f"retired__user_{user.id}_{user.email.split('@')[0]}@retired.invalid"
-    
+
     user.username = retired_username
     user.email = retired_email
     user.set_unusable_password()

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -200,6 +200,8 @@ def create_retirement_request_and_deactivate_account(user):
     """
     Adds user to retirement queue, unlinks social auth accounts, changes user passwords
     and delete tokens and activation keys
+    
+    Modified to include user ID in retired credentials to allow reuse of original credentials.
     """
     # Add user to retirement queue.
     UserRetirementStatus.create_retirement(user)
@@ -207,8 +209,13 @@ def create_retirement_request_and_deactivate_account(user):
     # Unlink LMS social auth accounts
     UserSocialAuth.objects.filter(user_id=user.id).delete()
 
-    # Change LMS password & email
-    user.email = get_retired_email_by_email(user.email)
+    # Change LMS password, username & email
+    # Include user ID to ensure uniqueness when retired credentials are reused
+    retired_username = f"retired__user_{user.id}_{user.username}"
+    retired_email = f"retired__user_{user.id}_{user.email.split('@')[0]}@retired.invalid"
+    
+    user.username = retired_username
+    user.email = retired_email
     user.set_unusable_password()
     user.save()
 

--- a/openedx/core/djangoapps/user_api/models.py
+++ b/openedx/core/djangoapps/user_api/models.py
@@ -340,6 +340,8 @@ class UserRetirementStatus(TimeStampedModel):
         """
         Creates a UserRetirementStatus for the given user, in the correct initial state. Will
         fail if the user already has a UserRetirementStatus row or if states are not yet populated.
+        
+        Modified to include user ID in retired credentials to allow reuse of original credentials.
         """
         try:
             pending = RetirementState.objects.all().order_by('state_execution_order')[0]
@@ -349,8 +351,9 @@ class UserRetirementStatus(TimeStampedModel):
         if cls.objects.filter(user=user).exists():
             raise RetirementStateError(f'User {user} already has a retirement status row!')
 
-        retired_username = get_retired_username_by_username(user.username)
-        retired_email = get_retired_email_by_email(user.email)
+        # Include user ID to ensure uniqueness when retired credentials are reused
+        retired_username = f"retired__user_{user.id}_{user.username}"
+        retired_email = f"retired__user_{user.id}_{user.email.split('@')[0]}@retired.invalid"
 
         UserRetirementRequest.create_retirement_request(user)
 

--- a/openedx/core/djangoapps/user_api/models.py
+++ b/openedx/core/djangoapps/user_api/models.py
@@ -340,7 +340,7 @@ class UserRetirementStatus(TimeStampedModel):
         """
         Creates a UserRetirementStatus for the given user, in the correct initial state. Will
         fail if the user already has a UserRetirementStatus row or if states are not yet populated.
-        
+
         Modified to include user ID in retired credentials to allow reuse of original credentials.
         """
         try:


### PR DESCRIPTION
## Description

This pull request enables retired usernames and emails to be reused for new user registrations, and prevents duplicate key errors when users with the same original credentials retire multiple times.

### What Changed

**1. Allow Credential Reuse After Retirement**
- Modified `is_username_retired()` and `is_email_retired()` functions to return `False`, allowing previously retired credentials to be available for new registrations
- This means when a user retires their account (username: `student`, email: `student@example.com`), a completely new user can later register with those same credentials

**2. Fix Duplicate Key Error on Multiple Retirements**
- Updated retirement process to include the user ID in retired credentials (e.g., `retired__user_5_student@retired.invalid` instead of `retired__user_hash@retired.invalid`)
- This ensures that when multiple users retire and re-register with the same original credentials, each retirement creates unique database entries

### Why These Changes

Previously, the system prevented any reuse of retired credentials to protect against identity confusion. However, this created a permanent "lock" on usernames and emails, preventing legitimate new users from using popular or common credentials that had been retired.

The new approach:
- ✅ Allows credential reuse for fresh, independent accounts
- ✅ Maintains audit trail in `user_api_userretirementstatus` table
- ✅ Prevents database conflicts when the same credentials are retired multiple times

