### PR TITLE
Fmo/cache user preferences

### DIFF
--- a/openedx/core/djangoapps/user_api/preferences/api.py
+++ b/openedx/core/djangoapps/user_api/preferences/api.py
@@ -6,6 +6,7 @@ API for managing user preferences.
 import logging
 
 from django.conf import settings
+from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError
 from django.utils.translation import gettext as _
@@ -32,6 +33,26 @@ from ..serializers import RawUserPreferenceSerializer
 
 log = logging.getLogger(__name__)
 
+USER_PREFERENCE_CACHE_TIMEOUT = getattr(settings, 'USER_PREFERENCE_CACHE_TIMEOUT', 5 * 60)
+USER_PREFERENCE_CACHE_KEY_PREFIX = getattr(settings, 'USER_PREFERENCE_CACHE_KEY_PREFIX', 'user_preferences')
+
+
+def _user_preferences_cache_key(user_id):
+    return f"{USER_PREFERENCE_CACHE_KEY_PREFIX}.{user_id}"
+
+
+def _get_cached_preferences(user):
+    """Return the cached preferences dict for a user, or None on a cache miss."""
+    return cache.get(_user_preferences_cache_key(user.id))
+
+
+def _set_cached_preferences(user, preferences):
+    cache.set(_user_preferences_cache_key(user.id), preferences, USER_PREFERENCE_CACHE_TIMEOUT)
+
+
+def _invalidate_user_preferences_cache(user):
+    cache.delete(_user_preferences_cache_key(user.id))
+
 
 @intercept_errors(UserAPIInternalError, ignore_errors=[UserAPIRequestError])
 def has_user_preference(requesting_user, preference_key, username=None):
@@ -55,7 +76,11 @@ def has_user_preference(requesting_user, preference_key, username=None):
          UserAPIInternalError: the operation failed due to an unexpected error.
     """
     existing_user = _get_authorized_user(requesting_user, username, allow_staff=True)
-    return UserPreference.has_value(existing_user, preference_key)
+    cached = _get_cached_preferences(existing_user)
+    if cached is None:
+        cached = UserPreference.get_all_preferences(existing_user)
+        _set_cached_preferences(existing_user, cached)
+    return preference_key in cached
 
 
 @intercept_errors(UserAPIInternalError, ignore_errors=[UserAPIRequestError])
@@ -80,7 +105,11 @@ def get_user_preference(requesting_user, preference_key, username=None):
          UserAPIInternalError: the operation failed due to an unexpected error.
     """
     existing_user = _get_authorized_user(requesting_user, username, allow_staff=True)
-    return UserPreference.get_value(existing_user, preference_key)
+    cached = _get_cached_preferences(existing_user)
+    if cached is None:
+        cached = UserPreference.get_all_preferences(existing_user)
+        _set_cached_preferences(existing_user, cached)
+    return cached.get(preference_key)
 
 
 @intercept_errors(UserAPIInternalError, ignore_errors=[UserAPIRequestError])
@@ -103,7 +132,12 @@ def get_user_preferences(requesting_user, username=None):
          UserAPIInternalError: the operation failed due to an unexpected error.
     """
     existing_user = _get_authorized_user(requesting_user, username, allow_staff=True)
-    return UserPreference.get_all_preferences(existing_user)
+    cached = _get_cached_preferences(existing_user)
+    if cached is not None:
+        return cached
+    preferences = UserPreference.get_all_preferences(existing_user)
+    _set_cached_preferences(existing_user, preferences)
+    return preferences
 
 
 @intercept_errors(UserAPIInternalError, ignore_errors=[UserAPIRequestError])
@@ -171,6 +205,7 @@ def update_user_preferences(requesting_user, update, user=None):
                 raise _create_preference_update_error(preference_key, preference_value, error)  # lint-amnesty, pylint: disable=raise-missing-from
         else:
             delete_user_preference(requesting_user, preference_key)
+    _invalidate_user_preferences_cache(user)
 
 
 @intercept_errors(UserAPIInternalError, ignore_errors=[UserAPIRequestError])
@@ -209,6 +244,7 @@ def set_user_preference(requesting_user, preference_key, preference_value, usern
             serializer.save()
         except Exception as error:
             raise _create_preference_update_error(preference_key, preference_value, error)  # lint-amnesty, pylint: disable=raise-missing-from
+        _invalidate_user_preferences_cache(existing_user)
 
 
 @intercept_errors(UserAPIInternalError, ignore_errors=[UserAPIRequestError])
@@ -254,6 +290,7 @@ def delete_user_preference(requesting_user, preference_key, username=None):
                 preference_key=preference_key
             ),
         )
+    _invalidate_user_preferences_cache(existing_user)
     return True
 
 


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR adds an emergency cache to the user preferences API.

## Supporting information

The reason for this is the high impact in ops that we see from the query:

```
SELECT `user_api_userpreference` . `id` , `user_api_userpreference` . `user_id` , `user_api_userpreference` . `key` , `user_api_userpreference` . `value` FROM `user_api_userpreference` WHERE ( `user_api_userpreference` . `key` = ? AND `user_api_userpreference` . `user_id` = ? ) LIMIT ? 
```

## Deadline

High priority to get the db stable.
