### PR TITLE
fix: studio swagger api-docs crashes with 500 error

### DIFF
--- a/openedx/core/djangoapps/content_libraries/rest_api/containers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/containers.py
@@ -9,12 +9,13 @@ from django.contrib.auth import get_user_model
 from django.db.transaction import non_atomic_requests
 from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 
 from opaque_keys.edx.locator import LibraryLocatorV2, LibraryContainerLocator
 from openedx_learning.api import authoring as authoring_api
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
-from rest_framework.status import HTTP_204_NO_CONTENT
+from rest_framework.status import HTTP_204_NO_CONTENT, HTTP_200_OK
 
 from openedx.core.djangoapps.content_libraries import api, permissions
 from openedx.core.lib.api.view_utils import view_auth_classes
@@ -137,7 +138,9 @@ class LibraryContainerChildrenView(GenericAPIView):
 
     @convert_exceptions
     @swagger_auto_schema(
-        responses={200: list[serializers.LibraryXBlockMetadataSerializer]}
+        responses={
+            HTTP_200_OK: serializers.UnionLibraryMetadataSerializer()
+        }
     )
     def get(self, request, container_key: LibraryContainerLocator):
         """
@@ -282,7 +285,16 @@ class LibraryContainerRestore(GenericAPIView):
     """
     View to restore soft-deleted library containers.
     """
+
     @convert_exceptions
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+        ),
+        responses={
+            HTTP_204_NO_CONTENT: "No content"
+        }
+    )
     def post(self, request, container_key: LibraryContainerLocator) -> Response:
         """
         Restores a soft-deleted library container
@@ -302,7 +314,21 @@ class LibraryContainerCollectionsView(GenericAPIView):
     """
     View to set collections for a container.
     """
+
     @convert_exceptions
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+        ),
+        responses={
+            HTTP_200_OK: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    'count': openapi.Schema(type=openapi.TYPE_INTEGER)
+                }
+            )
+        }
+    )
     def patch(self, request: RestRequest, container_key: LibraryContainerLocator) -> Response:
         """
         Sets Collections for a Component.
@@ -335,7 +361,18 @@ class LibraryContainerPublishView(GenericAPIView):
     """
     View to publish a container, or revert to last published.
     """
+
     @convert_exceptions
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+        ),
+        responses={
+            HTTP_200_OK: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+            )
+        }
+    )
     def post(self, request: RestRequest, container_key: LibraryContainerLocator) -> Response:
         """
         Publish the container and its children

--- a/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/rest_api/serializers.py
@@ -386,3 +386,12 @@ class ContentLibraryItemCollectionsUpdateSerializer(serializers.Serializer):
     """
 
     collection_keys = serializers.ListField(child=serializers.CharField(), allow_empty=True)
+
+
+class UnionLibraryMetadataSerializer(serializers.Serializer):
+    """
+    Union serializer for swagger api response.
+    """
+
+    type_a = LibraryXBlockMetadataSerializer(many=True, required=False)
+    type_b = LibraryContainerMetadataSerializer(many=True, required=False)


### PR DESCRIPTION
## Description
Backport of https://github.com/openedx/openedx-platform/pull/37099

## Before
<img width="1832" height="775" alt="image" src="https://github.com/user-attachments/assets/86246b30-b4b0-43e5-98e4-926bb846f742" />

## After
<img width="1835" height="1007" alt="image" src="https://github.com/user-attachments/assets/efe2df08-4258-40ec-8831-164ddb3306f5" />
