### PR TITLE
feat!: rm user db_constraing in CourseEnrollment

### DIFF
--- a/common/djangoapps/student/migrations/0047_coursenrollment_rm_user_foreign_db_constraint.py
+++ b/common/djangoapps/student/migrations/0047_coursenrollment_rm_user_foreign_db_constraint.py
@@ -1,0 +1,26 @@
+# rm user foreign key db constraint to avoid deadlocks when deleting users.
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('student', '0046_alter_userprofile_phone_number'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='courseenrollment',
+            name='user',
+            field=models.ForeignKey(db_constraint=False, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AlterField(
+            model_name='courseenrollmentallowed',
+            name='user',
+            field=models.ForeignKey(blank=True, db_constraint=False, help_text="First user which enrolled in the specified course through the specified e-mail. Once set, it won't change.", null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/common/djangoapps/student/models/course_enrollment.py
+++ b/common/djangoapps/student/models/course_enrollment.py
@@ -310,7 +310,7 @@ class CourseEnrollment(models.Model):
     """
     MODEL_TAGS = ['course', 'is_active', 'mode']
 
-    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    user = models.ForeignKey(User, on_delete=models.CASCADE, db_constraint=False)
 
     course = models.ForeignKey(
         CourseOverview,
@@ -1608,6 +1608,7 @@ class CourseEnrollmentAllowed(DeletableByUserValue, models.Model):
         help_text="First user which enrolled in the specified course through the specified e-mail. "
                   "Once set, it won't change.",
         on_delete=models.CASCADE,
+        db_constraint=False,
     )
 
     created = models.DateTimeField(auto_now_add=True, null=True, db_index=True)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description
[feat!: rm user db_constraing in CourseEnrollment](https://github.com/nelc/edx-platform/pull/78/changes/a022b690a6b779d82592b6b1844d970d4fbec39b)

#### Consideration

The model get_or_create receives an user object. So is controlled that user is used to create a course_enrollment without using a random int.

https://github.com/nelc/edx-platform/blob/a022b690a6b779d82592b6b1844d970d4fbec39b/common/djangoapps/student/models/course_enrollment.py#L375-L407
## Test
Run migrations 

<img width="1332" height="728" alt="image" src="https://github.com/user-attachments/assets/c0abba22-3f98-4b24-b439-fc8f67b6f6e5" />

