### PR TITLE
refactor(course_modes): resolve default mode slug at runtime instead …

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -187,7 +187,6 @@ class CourseMode(models.Model):
         settings.COURSE_MODE_DEFAULTS['ios_sku'],
         settings.COURSE_MODE_DEFAULTS['bulk_sku'],
     )
-    DEFAULT_MODE_SLUG = settings.COURSE_MODE_DEFAULTS['slug']
 
     ALL_MODES = [
         AUDIT,
@@ -299,7 +298,7 @@ class CourseMode(models.Model):
         Returns the default mode slug to be used in the CourseEnrollment model mode field
         as the default value.
         """
-        return cls.DEFAULT_MODE_SLUG
+        return settings.COURSE_MODE_DEFAULTS['slug']
 
     @classmethod
     def all_modes_for_courses(cls, course_id_list):

--- a/common/djangoapps/course_modes/tests/factories.py
+++ b/common/djangoapps/course_modes/tests/factories.py
@@ -19,7 +19,7 @@ class CourseModeFactory(DjangoModelFactory):  # lint-amnesty, pylint: disable=mi
     class Meta:
         model = CourseMode
 
-    mode_slug = CourseMode.DEFAULT_MODE_SLUG
+    mode_slug = CourseMode.get_default_mode_slug()
     currency = 'usd'
     expiration_datetime = None
     suggested_prices = ''

--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -332,7 +332,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
 
     def test_successful_default_enrollment(self):
         # Create the course modes
-        for mode in (CourseMode.DEFAULT_MODE_SLUG, 'verified'):
+        for mode in (CourseMode.get_default_mode_slug(), 'verified'):
             CourseModeFactory.create(mode_slug=mode, course_id=self.course.id)
 
         # Enroll the user in the default mode (honor) to emulate
@@ -345,11 +345,11 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
 
         # Explicitly select the honor mode (POST request)
         choose_track_url = reverse('course_modes_choose', args=[str(self.course.id)])
-        self.client.post(choose_track_url, self.POST_PARAMS_FOR_COURSE_MODE[CourseMode.DEFAULT_MODE_SLUG])
+        self.client.post(choose_track_url, self.POST_PARAMS_FOR_COURSE_MODE[CourseMode.get_default_mode_slug()])
 
         # Verify that the user's enrollment remains unchanged
         mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
-        assert mode == CourseMode.DEFAULT_MODE_SLUG
+        assert mode == CourseMode.get_default_mode_slug()
         assert is_active is True
 
     @skip_unless_lms

--- a/common/djangoapps/student/models/course_enrollment.py
+++ b/common/djangoapps/student/models/course_enrollment.py
@@ -407,7 +407,7 @@ class CourseEnrollment(models.Model):
             user=user,
             course_id=course_key,
             defaults={
-                'mode': CourseMode.DEFAULT_MODE_SLUG,
+                'mode': CourseMode.get_default_mode_slug(),
                 'is_active': False
             }
         )

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -90,12 +90,12 @@ class EnrollmentTest(UrlResetMixin, ModuleStoreTestCase, OpenEdxEventsTestMixin)
         # Default (no course modes in the database)
         # Expect that we're redirected to the dashboard
         # and automatically enrolled
-        ([], '', CourseMode.DEFAULT_MODE_SLUG),
+        ([], '', CourseMode.get_default_mode_slug()),
 
         # Audit / Verified
         # We should always go to the "choose your course" page.
         # We should also be enrolled as the default mode.
-        (['verified', 'audit'], 'course_modes_choose', CourseMode.DEFAULT_MODE_SLUG),
+        (['verified', 'audit'], 'course_modes_choose', CourseMode.get_default_mode_slug()),
 
         # Audit / Verified / Honor
         # We should always go to the "choose your course" page.

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -645,7 +645,7 @@ class EnrollmentEventTestMixin(EventTestMixin):
             {
                 'course_id': str(course_key),
                 'user_id': user.pk,
-                'mode': CourseMode.DEFAULT_MODE_SLUG
+                'mode': CourseMode.get_default_mode_slug()
             }
         )
         self.mock_tracker.reset_mock()
@@ -662,7 +662,7 @@ class EnrollmentEventTestMixin(EventTestMixin):
             {
                 'course_id': str(course_key),
                 'user_id': user.pk,
-                'mode': CourseMode.DEFAULT_MODE_SLUG
+                'mode': CourseMode.get_default_mode_slug()
             }
         )
         self.mock_tracker.reset_mock()
@@ -927,7 +927,7 @@ class ChangeEnrollmentViewTest(ModuleStoreTestCase):
             self.user, self.course.id
         )
         assert is_active
-        assert enrollment_mode == CourseMode.DEFAULT_MODE_SLUG
+        assert enrollment_mode == CourseMode.get_default_mode_slug()
 
     def test_cannot_enroll_if_already_enrolled(self):
         """
@@ -977,7 +977,7 @@ class ChangeEnrollmentViewTest(ModuleStoreTestCase):
             self.user, self.course.id
         )
         assert is_active
-        assert enrollment_mode == CourseMode.DEFAULT_MODE_SLUG
+        assert enrollment_mode == CourseMode.get_default_mode_slug()
 
 
 class AnonymousLookupTable(ModuleStoreTestCase):

--- a/lms/djangoapps/commerce/api/v0/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v0/tests/test_views.py
@@ -142,7 +142,7 @@ class BasketsViewTests(UserMixin, ModuleStoreTestCase):
         )
         self.assertResponseMessage(response, msg)
 
-    def _test_course_without_sku(self, enrollment_mode=CourseMode.DEFAULT_MODE_SLUG):
+    def _test_course_without_sku(self, enrollment_mode=CourseMode.get_default_mode_slug()):
         """
         Validates the view when course has no CourseModes with SKUs.
         """

--- a/lms/djangoapps/commerce/api/v0/views.py
+++ b/lms/djangoapps/commerce/api/v0/views.py
@@ -64,7 +64,7 @@ class BasketsView(APIView):
 
         return True, course_key, None
 
-    def _enroll(self, course_key, user, mode=CourseMode.DEFAULT_MODE_SLUG):
+    def _enroll(self, course_key, user, mode=CourseMode.get_default_mode_slug()):
         """ Enroll the user in the course. """
         add_enrollment(user.username, str(course_key), mode)
 

--- a/lms/djangoapps/commerce/api/v1/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_views.py
@@ -412,7 +412,7 @@ class CourseRetrieveUpdateViewTests(CourseApiViewTestMixin, ModuleStoreTestCase)
 
         expected_modes = [
             CourseMode(
-                mode_slug=CourseMode.DEFAULT_MODE_SLUG,
+                mode_slug=CourseMode.get_default_mode_slug(),
                 min_price=150, currency='USD',
                 sku='ABC123',
                 bulk_sku='BULK-ABC123'

--- a/lms/djangoapps/course_blocks/transformers/tests/helpers.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/helpers.py
@@ -258,7 +258,7 @@ class BlockParentsMapTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
         self.staff = UserFactory.create(is_staff=True, username='test_staff', password=self.password)
         CourseEnrollmentFactory.create(
             is_active=True,
-            mode=CourseMode.DEFAULT_MODE_SLUG,
+            mode=CourseMode.get_default_mode_slug(),
             user=self.student,
             course_id=self.course.id
         )

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -62,8 +62,8 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
 
         self.course_mode = CourseMode(
             course_id=self.purchase_course.id,
-            mode_slug=CourseMode.DEFAULT_MODE_SLUG,
-            mode_display_name=CourseMode.DEFAULT_MODE_SLUG,
+            mode_slug=CourseMode.get_default_mode_slug(),
+            mode_display_name=CourseMode.get_default_mode_slug(),
             min_price=10
         )
         self.course_mode.save()

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -1144,9 +1144,9 @@ class TestProctoringRendering(ModuleStoreTestCase):
             )
 
     @ddt.data(
-        (CourseMode.DEFAULT_MODE_SLUG, False, None, None),
+        (CourseMode.get_default_mode_slug(), False, None, None),
         (
-            CourseMode.DEFAULT_MODE_SLUG,
+            CourseMode.get_default_mode_slug(),
             True,
             'eligible',
             {
@@ -1157,7 +1157,7 @@ class TestProctoringRendering(ModuleStoreTestCase):
             }
         ),
         (
-            CourseMode.DEFAULT_MODE_SLUG,
+            CourseMode.get_default_mode_slug(),
             True,
             'submitted',
             {
@@ -1168,7 +1168,7 @@ class TestProctoringRendering(ModuleStoreTestCase):
             }
         ),
         (
-            CourseMode.DEFAULT_MODE_SLUG,
+            CourseMode.get_default_mode_slug(),
             True,
             'error',
             {

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -1795,7 +1795,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         course_enrollment = CourseEnrollment.objects.get(
             user=self.enrolled_student, course_id=self.course.id
         )
-        assert course_enrollment.mode == CourseMode.DEFAULT_MODE_SLUG
+        assert course_enrollment.mode == CourseMode.get_default_mode_slug()
 
     def test_reason_is_persisted(self):
         """

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -73,7 +73,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
 
         self.course_mode = CourseMode(
             course_id=self.course.id,
-            mode_slug=CourseMode.DEFAULT_MODE_SLUG,
+            mode_slug=CourseMode.get_default_mode_slug(),
             mode_display_name=CourseMode.DEFAULT_MODE.name,
             min_price=40
         )
@@ -620,7 +620,7 @@ class TestInstructorDashboardPerformance(ModuleStoreTestCase, LoginEnrollmentTes
 
         self.course_mode = CourseMode(
             course_id=self.course.id,
-            mode_slug=CourseMode.DEFAULT_MODE_SLUG,
+            mode_slug=CourseMode.get_default_mode_slug(),
             mode_display_name=CourseMode.DEFAULT_MODE.name,
             min_price=40
         )

--- a/lms/djangoapps/instructor_task/tests/test_tasks.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks.py
@@ -163,7 +163,7 @@ class TestInstructorTasks(InstructorTaskModuleTestCase):
             )
         return enrolled_students
 
-    def _create_and_enroll_students(self, num_students, mode=CourseMode.DEFAULT_MODE_SLUG):
+    def _create_and_enroll_students(self, num_students, mode=CourseMode.get_default_mode_slug()):
         """Create & enroll students for testing"""
         return [
             self.create_student(username='robot%d' % i, email='robot+test+%d@edx.org' % i, mode=mode)

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -136,7 +136,7 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
         assert f'course_info/{self.course.id}/updates' in found_course['course_updates']
         assert f'course_info/{self.course.id}/handouts' in found_course['course_handouts']
         assert found_course['id'] == str(self.course.id)
-        assert courses[0]['mode'] == CourseMode.DEFAULT_MODE_SLUG
+        assert courses[0]['mode'] == CourseMode.get_default_mode_slug()
         assert courses[0]['course']['subscription_id'] == self.course.clean_id(padding_char='_')
 
         expected_course_image_url = course_image_url(self.course)

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -830,7 +830,7 @@ class TestPayAndVerifyView(UrlResetMixin, ModuleStoreTestCase, XssTestMixin, Tes
 
         return course
 
-    def _enroll(self, course_key, mode=CourseMode.DEFAULT_MODE_SLUG):
+    def _enroll(self, course_key, mode=CourseMode.get_default_mode_slug()):
         """Enroll the user in a course. """
         CourseEnrollmentFactory.create(
             user=self.user,
@@ -1009,8 +1009,8 @@ class TestPayAndVerifyView(UrlResetMixin, ModuleStoreTestCase, XssTestMixin, Tes
         """Check the course information on the page. """
         mode_display_name = "Introduction à l'astrophysique"
         course = CourseFactory.create(display_name=mode_display_name)
-        for course_mode in [CourseMode.DEFAULT_MODE_SLUG, "verified"]:
-            min_price = (self.MIN_PRICE if course_mode != CourseMode.DEFAULT_MODE_SLUG else 0)
+        for course_mode in [CourseMode.get_default_mode_slug(), "verified"]:
+            min_price = (self.MIN_PRICE if course_mode != CourseMode.get_default_mode_slug() else 0)
             CourseModeFactory.create(
                 course_id=course.id,
                 mode_slug=course_mode,

--- a/openedx/core/djangoapps/enrollments/api.py
+++ b/openedx/core/djangoapps/enrollments/api.py
@@ -211,7 +211,7 @@ def add_enrollment(
 ):
     """Enrolls a user in a course.
 
-    Enrolls a user in a course. If the mode is not specified, this will default to `CourseMode.DEFAULT_MODE_SLUG`.
+    Enrolls a user in a course. If the mode is not specified, this will default to `CourseMode.get_default_mode_slug()`.
 
     Arguments:
         username: The user to enroll.
@@ -472,14 +472,14 @@ def _default_course_mode(course_id):
     course_modes = CourseMode.modes_for_course(CourseKey.from_string(course_id))
     available_modes = [m.slug for m in course_modes]
 
-    if CourseMode.DEFAULT_MODE_SLUG in available_modes:
-        return CourseMode.DEFAULT_MODE_SLUG
+    if CourseMode.get_default_mode_slug() in available_modes:
+        return CourseMode.get_default_mode_slug()
     elif 'audit' in available_modes:
         return 'audit'
     elif 'honor' in available_modes:
         return 'honor'
 
-    return CourseMode.DEFAULT_MODE_SLUG
+    return CourseMode.get_default_mode_slug()
 
 
 def validate_course_mode(course_id, mode, is_active=None, include_expired=False):

--- a/openedx/core/djangoapps/enrollments/tests/test_api.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_api.py
@@ -62,7 +62,7 @@ class EnrollmentTest(CacheIsolationTestCase):
         assert result == get_result
 
     @ddt.data(
-        ([CourseMode.DEFAULT_MODE_SLUG, 'verified', 'credit'], CourseMode.DEFAULT_MODE_SLUG),
+        ([CourseMode.get_default_mode_slug(), 'verified', 'credit'], CourseMode.get_default_mode_slug()),
         (['audit', 'verified', 'credit'], 'audit'),
         (['honor', 'verified', 'credit'], 'honor'),
     )

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -62,7 +62,7 @@ class EnrollmentTestMixin:
             expected_status=status.HTTP_200_OK,
             email_opt_in=None,
             as_server=False,
-            mode=CourseMode.DEFAULT_MODE_SLUG,
+            mode=CourseMode.get_default_mode_slug(),
             is_active=None,
             enrollment_attributes=None,
             min_mongo_calls=0,
@@ -207,12 +207,12 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
     @ddt.data(
         # Default (no course modes in the database)
         # Expect that users are automatically enrolled as the default
-        ([], CourseMode.DEFAULT_MODE_SLUG),
+        ([], CourseMode.get_default_mode_slug()),
 
         # Audit / Verified
         # We should always go to the "choose your course" page.
         # We should also be enrolled as the default.
-        ([CourseMode.VERIFIED, CourseMode.AUDIT], CourseMode.DEFAULT_MODE_SLUG),
+        ([CourseMode.VERIFIED, CourseMode.AUDIT], CourseMode.get_default_mode_slug()),
     )
     @ddt.unpack
     def test_enroll(self, course_modes, enrollment_mode):
@@ -415,8 +415,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
     def test_check_enrollment(self):
         CourseModeFactory.create(
             course_id=self.course.id,
-            mode_slug=CourseMode.DEFAULT_MODE_SLUG,
-            mode_display_name=CourseMode.DEFAULT_MODE_SLUG,
+            mode_slug=CourseMode.get_default_mode_slug(),
+            mode_display_name=CourseMode.get_default_mode_slug(),
         )
         # Create an enrollment
         self.assert_enrollment_status()
@@ -430,7 +430,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         data = json.loads(resp.content.decode('utf-8'))
         assert str(self.course.id) == data['course_details']['course_id']
         assert self.course.display_name_with_default == data['course_details']['course_name']
-        assert CourseMode.DEFAULT_MODE_SLUG == data['mode']
+        assert CourseMode.get_default_mode_slug() == data['mode']
         assert data['is_active']
 
     @ddt.data(
@@ -479,8 +479,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
     def test_user_not_specified(self):
         CourseModeFactory.create(
             course_id=self.course.id,
-            mode_slug=CourseMode.DEFAULT_MODE_SLUG,
-            mode_display_name=CourseMode.DEFAULT_MODE_SLUG,
+            mode_slug=CourseMode.get_default_mode_slug(),
+            mode_display_name=CourseMode.get_default_mode_slug(),
         )
         # Create an enrollment
         self.assert_enrollment_status()
@@ -490,7 +490,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         assert resp.status_code == status.HTTP_200_OK
         data = json.loads(resp.content.decode('utf-8'))
         assert str(self.course.id) == data['course_details']['course_id']
-        assert CourseMode.DEFAULT_MODE_SLUG == data['mode']
+        assert CourseMode.get_default_mode_slug() == data['mode']
         assert data['is_active']
 
     def test_user_not_authenticated(self):
@@ -527,8 +527,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         # Try to enroll a user that is not the authenticated user.
         CourseModeFactory.create(
             course_id=self.course.id,
-            mode_slug=CourseMode.DEFAULT_MODE_SLUG,
-            mode_display_name=CourseMode.DEFAULT_MODE_SLUG,
+            mode_slug=CourseMode.get_default_mode_slug(),
+            mode_display_name=CourseMode.get_default_mode_slug(),
         )
         self.assert_enrollment_status(username=self.other_user.username, expected_status=status.HTTP_404_NOT_FOUND)
         # Verify that the server still has access to this endpoint.
@@ -561,8 +561,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         for course in self.course, other_course:
             CourseModeFactory.create(
                 course_id=str(course.id),
-                mode_slug=CourseMode.DEFAULT_MODE_SLUG,
-                mode_display_name=CourseMode.DEFAULT_MODE_SLUG,
+                mode_slug=CourseMode.get_default_mode_slug(),
+                mode_display_name=CourseMode.get_default_mode_slug(),
             )
             self.assert_enrollment_status(
                 course_id=str(course.id),
@@ -755,8 +755,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         self.rate_limit_config.save()
         CourseModeFactory.create(
             course_id=self.course.id,
-            mode_slug=CourseMode.DEFAULT_MODE_SLUG,
-            mode_display_name=CourseMode.DEFAULT_MODE_SLUG,
+            mode_slug=CourseMode.get_default_mode_slug(),
+            mode_display_name=CourseMode.get_default_mode_slug(),
         )
 
         for attempt in range(self.rate_limit + 2):
@@ -858,7 +858,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
     def test_update_enrollment_with_mode(self):
         """With the right API key, update an existing enrollment with a new mode. """
         # Create an honor and verified mode for a course. This allows an update.
-        for mode in [CourseMode.DEFAULT_MODE_SLUG, CourseMode.VERIFIED]:
+        for mode in [CourseMode.get_default_mode_slug(), CourseMode.VERIFIED]:
             CourseModeFactory.create(
                 course_id=self.course.id,
                 mode_slug=mode,
@@ -872,7 +872,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         assert CourseEnrollment.is_enrolled(self.user, self.course.id)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
         assert is_active
-        assert course_mode == CourseMode.DEFAULT_MODE_SLUG
+        assert course_mode == CourseMode.get_default_mode_slug()
 
         # Check that the enrollment upgraded to verified.
         self.assert_enrollment_status(as_server=True, mode=CourseMode.VERIFIED, expected_status=status.HTTP_200_OK)
@@ -884,7 +884,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         """With the right API key, update an existing enrollment with credit
         mode and set enrollment attributes.
         """
-        for mode in [CourseMode.DEFAULT_MODE_SLUG, CourseMode.CREDIT_MODE]:
+        for mode in [CourseMode.get_default_mode_slug(), CourseMode.CREDIT_MODE]:
             CourseModeFactory.create(
                 course_id=self.course.id,
                 mode_slug=mode,
@@ -898,7 +898,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         assert CourseEnrollment.is_enrolled(self.user, self.course.id)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
         assert is_active
-        assert course_mode == CourseMode.DEFAULT_MODE_SLUG
+        assert course_mode == CourseMode.get_default_mode_slug()
 
         # Check that the enrollment upgraded to credit.
         enrollment_attributes = [{
@@ -920,7 +920,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         """Check response status is bad request when invalid enrollment
         attributes are passed
         """
-        for mode in [CourseMode.DEFAULT_MODE_SLUG, CourseMode.CREDIT_MODE]:
+        for mode in [CourseMode.get_default_mode_slug(), CourseMode.CREDIT_MODE]:
             CourseModeFactory.create(
                 course_id=self.course.id,
                 mode_slug=mode,
@@ -934,7 +934,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         assert CourseEnrollment.is_enrolled(self.user, self.course.id)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
         assert is_active
-        assert course_mode == CourseMode.DEFAULT_MODE_SLUG
+        assert course_mode == CourseMode.get_default_mode_slug()
 
         # Check that the enrollment upgraded to credit.
         enrollment_attributes = [{
@@ -950,12 +950,12 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         )
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
         assert is_active
-        assert course_mode == CourseMode.DEFAULT_MODE_SLUG
+        assert course_mode == CourseMode.get_default_mode_slug()
 
     def test_downgrade_enrollment_with_mode(self):
         """With the right API key, downgrade an existing enrollment with a new mode. """
         # Create an honor and verified mode for a course. This allows an update.
-        for mode in [CourseMode.DEFAULT_MODE_SLUG, CourseMode.VERIFIED]:
+        for mode in [CourseMode.get_default_mode_slug(), CourseMode.VERIFIED]:
             CourseModeFactory.create(
                 course_id=self.course.id,
                 mode_slug=mode,
@@ -974,17 +974,17 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         # Check that the enrollment was downgraded to the default mode.
         self.assert_enrollment_status(
             as_server=True,
-            mode=CourseMode.DEFAULT_MODE_SLUG,
+            mode=CourseMode.get_default_mode_slug(),
             expected_status=status.HTTP_200_OK
         )
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
         assert is_active
-        assert course_mode == CourseMode.DEFAULT_MODE_SLUG
+        assert course_mode == CourseMode.get_default_mode_slug()
 
     @ddt.data(
-        ((CourseMode.DEFAULT_MODE_SLUG, ), CourseMode.DEFAULT_MODE_SLUG),
-        ((CourseMode.DEFAULT_MODE_SLUG, CourseMode.VERIFIED), CourseMode.DEFAULT_MODE_SLUG),
-        ((CourseMode.DEFAULT_MODE_SLUG, CourseMode.VERIFIED), CourseMode.VERIFIED),
+        ((CourseMode.get_default_mode_slug(), ), CourseMode.get_default_mode_slug()),
+        ((CourseMode.get_default_mode_slug(), CourseMode.VERIFIED), CourseMode.get_default_mode_slug()),
+        ((CourseMode.get_default_mode_slug(), CourseMode.VERIFIED), CourseMode.VERIFIED),
         ((CourseMode.PROFESSIONAL, ), CourseMode.PROFESSIONAL),
         ((CourseMode.NO_ID_PROFESSIONAL_MODE, ), CourseMode.NO_ID_PROFESSIONAL_MODE),
         ((CourseMode.VERIFIED, CourseMode.CREDIT_MODE), CourseMode.VERIFIED),
@@ -1028,7 +1028,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         # in which the default mode doesn't exist.
         expected_status = (
             status.HTTP_200_OK
-            if CourseMode.DEFAULT_MODE_SLUG in configured_modes
+            if CourseMode.get_default_mode_slug() in configured_modes
             else status.HTTP_400_BAD_REQUEST
         )
         self.assert_enrollment_status(
@@ -1087,7 +1087,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
     def test_change_mode_from_user(self):
         """Users should not be able to alter the enrollment mode on an enrollment. """
         # Create a default and a verified mode for a course. This allows an update.
-        for mode in [CourseMode.DEFAULT_MODE_SLUG, CourseMode.VERIFIED]:
+        for mode in [CourseMode.get_default_mode_slug(), CourseMode.VERIFIED]:
             CourseModeFactory.create(
                 course_id=self.course.id,
                 mode_slug=mode,
@@ -1101,13 +1101,13 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         assert CourseEnrollment.is_enrolled(self.user, self.course.id)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
         assert is_active
-        assert course_mode == CourseMode.DEFAULT_MODE_SLUG
+        assert course_mode == CourseMode.get_default_mode_slug()
 
         # Get a 403 response when trying to upgrade yourself.
         self.assert_enrollment_status(mode=CourseMode.VERIFIED, expected_status=status.HTTP_403_FORBIDDEN)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
         assert is_active
-        assert course_mode == CourseMode.DEFAULT_MODE_SLUG
+        assert course_mode == CourseMode.get_default_mode_slug()
 
     @ddt.data(*itertools.product(
         (CourseMode.HONOR, CourseMode.VERIFIED),
@@ -1175,12 +1175,12 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
 
     @ddt.data(
         (True, CourseMode.VERIFIED),
-        (False, CourseMode.DEFAULT_MODE_SLUG)
+        (False, CourseMode.get_default_mode_slug())
     )
     @ddt.unpack
     def test_update_enrollment_with_expired_mode(self, using_api_key, updated_mode):
         """Verify that if verified mode is expired than it's enrollment cannot be updated. """
-        for mode in [CourseMode.DEFAULT_MODE_SLUG, CourseMode.VERIFIED]:
+        for mode in [CourseMode.get_default_mode_slug(), CourseMode.VERIFIED]:
             CourseModeFactory.create(
                 course_id=self.course.id,
                 mode_slug=mode,
@@ -1194,7 +1194,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         assert CourseEnrollment.is_enrolled(self.user, self.course.id)
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
         assert is_active
-        assert course_mode == CourseMode.DEFAULT_MODE_SLUG
+        assert course_mode == CourseMode.get_default_mode_slug()
 
         # Change verified mode expiration.
         mode = CourseMode.objects.get(course_id=self.course.id, mode_slug=CourseMode.VERIFIED)
@@ -1256,8 +1256,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         )
         CourseModeFactory.create(
             course_id=self.course.id,
-            mode_slug=CourseMode.DEFAULT_MODE_SLUG,
-            mode_display_name=CourseMode.DEFAULT_MODE_SLUG,
+            mode_slug=CourseMode.get_default_mode_slug(),
+            mode_display_name=CourseMode.get_default_mode_slug(),
         )
         consent_kwargs = {
             'username': self.user.username,
@@ -1282,7 +1282,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         the enrollment is being created or updated.
         """
         course_key = self.course.id
-        for mode in [CourseMode.DEFAULT_MODE_SLUG, CourseMode.VERIFIED]:
+        for mode in [CourseMode.get_default_mode_slug(), CourseMode.VERIFIED]:
             CourseModeFactory.create(
                 course_id=course_key,
                 mode_slug=mode,
@@ -1315,7 +1315,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
             'name': 'order_number',
             'value': order_number,
         }]
-        mode = CourseMode.DEFAULT_MODE_SLUG
+        mode = CourseMode.get_default_mode_slug()
         self.assert_enrollment_status(
             as_server=True,
             mode=mode,
@@ -1552,7 +1552,7 @@ class UnenrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase):
         for course in self.courses:
             CourseModeFactory.create(
                 course_id=str(course.id),
-                mode_slug=CourseMode.DEFAULT_MODE_SLUG,
+                mode_slug=CourseMode.get_default_mode_slug(),
                 mode_display_name=CourseMode.DEFAULT_MODE,
             )
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -175,7 +175,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         params = [
             ('course_id', 'edX/DemoX/Demo_Course'),
             ('enrollment_action', 'enroll'),
-            ('course_mode', CourseMode.DEFAULT_MODE_SLUG),
+            ('course_mode', CourseMode.get_default_mode_slug()),
             ('email_opt_in', 'true'),
             ('next', '/custom/final/destination')
         ]
@@ -228,7 +228,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         params = [
             ('course_id', 'course-v1:Org+Course+Run'),
             ('enrollment_action', 'enroll'),
-            ('course_mode', CourseMode.DEFAULT_MODE_SLUG),
+            ('course_mode', CourseMode.get_default_mode_slug()),
             ('email_opt_in', 'true'),
             ('next', '/custom/final/destination'),
         ]


### PR DESCRIPTION
## Description
Currently, the default course enrollment mode slug is evaluated and frozen at import time during server startup via the static class attribute `CourseMode.DEFAULT_MODE_SLUG = settings.COURSE_MODE_DEFAULTS['slug']`. 

This implementation restricts flexibility if the active Django settings context changes or needs to be evaluated dynamically beyond the initial boot sequence.

This PR refactors the class to remove the static `DEFAULT_MODE_SLUG` constant and updates all internal references to use the `get_default_mode_slug()` class method instead. The method now directly fetches `settings.COURSE_MODE_DEFAULTS['slug']` on invocation, effectively shifting the configuration evaluation from import-time to runtime.