### PR TITLE
fix(rtl): use CSS logical properties for problem blocks and remove ha…

### DIFF
--- a/common/static/sass/_builtin-block-variables.scss
+++ b/common/static/sass/_builtin-block-variables.scss
@@ -11,7 +11,6 @@
 @import 'cms/static/sass/partials/cms/theme/_variables';
 @import 'cms/static/sass/partials/cms/theme/_variables-v1';
 @import 'bootstrap/scss/variables';
-@import 'vendor/bi-app/bi-app-ltr';
 @import 'edx-pattern-library-shims/base/_variables.scss';
 
 :root {

--- a/xmodule/static/css-builtin-blocks/ProblemBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/ProblemBlockDisplay.css
@@ -225,7 +225,7 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input[type="checkbox"],
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input[type="checkbox"] {
     margin: calc((var(--baseline, 20px) / 4));
-    margin-right: calc((var(--baseline, 20px) / 2));
+    margin-inline-end: calc((var(--baseline, 20px) / 2));
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input:focus+label,
@@ -394,7 +394,7 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup label {
     padding: calc((var(--baseline, 20px) / 2));
-    padding-left: calc((var(--baseline, 20px) * 2.3));
+    padding-inline-start: calc((var(--baseline, 20px) * 2.3));
     position: relative;
     font-size: var(--base-font-size, 18px);
     line-height: normal;
@@ -403,7 +403,7 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input[type="radio"],
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input[type="checkbox"] {
-    left: 0.5625em;
+    inset-inline-start: 0.5625em;
     position: absolute;
     top: 0.35em;
     width: calc(var(--baseline, 20px) * 1.1);


### PR DESCRIPTION
# Description

This PR fixes styling and alignment issues when the platform is rendered in Right-to-Left (RTL) languages, specifically within the Problem Blocks (choice groups, radio buttons, and checkboxes). 

Previously, the layout relied on physical CSS properties that forced elements to the left side regardless of the language direction. Additionally, a hardcoded LTR import in the SCSS architecture was overriding the dynamic RTL variables.

## Changes Made

* **`common/static/sass/_builtin-block-variables.scss`**: 
  * Removed the `@import 'vendor/bi-app/bi-app-ltr';` line. This prevents the LTR variables from overriding the `$bi-app-left` configurations when the platform is compiling the RTL stylesheet.
* **`xmodule/static/css-builtin-blocks/ProblemBlockDisplay.css`**: 
  * Modernized the layout by replacing physical directional properties with CSS logical properties.
  * Replaced `margin-right` with `margin-inline-end`.
  * Replaced `padding-left` with `padding-inline-start`.
  * Replaced `left` with `inset-inline-start`.

## Impact

By delegating the alignment to the browser using logical properties, elements like radio buttons and checkboxes will now automatically mirror their position based on the `dir="rtl"` or `dir="ltr"` HTML attribute, fixing the UI without needing separate overriding stylesheets.

## Before
#### EN
<img width="1892" height="704" alt="image" src="https://github.com/user-attachments/assets/53221cde-ca87-4cfa-bd75-69f0bc98ed5a" />

#### AR
<img width="1892" height="704" alt="image" src="https://github.com/user-attachments/assets/e6a54f9c-e4f5-453d-a41b-78ae9060ee23" />


## After
#### EN
<img width="1892" height="704" alt="image" src="https://github.com/user-attachments/assets/e1c91ced-6f02-4d2e-aceb-0b2b5242dbc7" />

#### AR
<img width="1892" height="704" alt="image" src="https://github.com/user-attachments/assets/9daa7978-d332-4cef-9ea5-75802b104933" />
