### PR TITLE
refactor: defer reverse_usage_url import to method scope to avoid LMS…

### DIFF
--- a/cms/djangoapps/contentstore/course_group_config.py
+++ b/cms/djangoapps/contentstore/course_group_config.py
@@ -9,7 +9,6 @@ from collections import defaultdict
 
 from django.utils.translation import gettext as _
 
-from cms.djangoapps.contentstore.utils import reverse_usage_url
 from common.djangoapps.util.db import MYSQL_MAX_INT, generate_int_id
 from lms.lib.utils import get_parent_unit
 
@@ -123,6 +122,22 @@ class GroupConfiguration:
         """
         Get usage info for unit/block.
         """
+        # MIGRATION NELC NOTE:
+        # This import was originally at the top of the file:
+        #     from cms.djangoapps.contentstore.utils import reverse_usage_url
+        #
+        # However, when the LMS loads this module (because we force CMS signal
+        # registration in LMS via `from cms.djangoapps.contentstore.signals import handlers`) in eox-nelp,
+        # importing `reverse_usage_url` at the top level triggers dependencies on
+        # `openedx.core.djangoapps.content.search`, which does not exist in the LMS
+        # context. This causes runtime errors when starting LMS.
+        #
+        # To fix this, we moved the import into `_get_usage_dict`, which is the only
+        # method that uses it. This way:
+        #   - In CMS, the function still works normally.
+        #   - In LMS, the import is never executed, avoiding the error.
+        from cms.djangoapps.contentstore.utils import reverse_usage_url
+
         parent_unit = get_parent_unit(block)
 
         if unit == parent_unit and not block.has_children:


### PR DESCRIPTION

## Description

The `GroupConfiguration` class previously imported `reverse_usage_url` at the top level of `course_group_config.py`. When CMS signals were explicitly registered in eox-nelp (`from cms.djangoapps.contentstore.signals import handlers`), this caused the LMS to load CMS modules that referenced `openedx.core.djangoapps.content.search`, which is not available in the LMS context. As a result, LMS startup failed.

### Change
- Relocated the `reverse_usage_url` import into `_get_usage_dict`, which is the only method that uses it.

### Impact
- **CMS**: No functional change — `_get_usage_dict` still imports and uses `reverse_usage_url`.
- **LMS**: Import is not executed during startup, preventing dependency errors when loading CMS signals.

### Notes
This is a **refactor** for runtime safety and better separation of LMS vs CMS context. 
No behavior change for end users or CMS functionality.

Issue [FUTUREX-1331](https://edunext.atlassian.net/browse/FUTUREX-1331)
Migration pr of  [#61](https://github.com/nelc/edx-platform/pull/61)