### PR TITLE
feat: add course type field to advanced settings and course info index

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -590,6 +590,7 @@ class CourseAboutSearchIndexer(CoursewareSearchIndexer):
         AboutInfo("language", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("invitation_only", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("catalog_visibility", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
+        AboutInfo("course_type", AboutInfo.ANALYSE | AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
     ]
 
     @classmethod

--- a/xmodule/course_block.py
+++ b/xmodule/course_block.py
@@ -1077,6 +1077,15 @@ class CourseFields:  # lint-amnesty, pylint: disable=missing-class-docstring
         scope=Scope.settings
     )
 
+    course_type = String(
+        display_name=_("Course Type"),
+        help=_(
+            "Content type that helps the student to filter courses which are more interesting for them."
+        ),
+        default=None,
+        scope=Scope.settings,
+    )
+
 
 class CourseBlock(
     CourseFields,


### PR DESCRIPTION
### Description
Introduces a new Course Type advanced setting, allowing students to filter courses by topic or interest.
### How to test

1. Go to the advanced setting section and check course Type option. (course authoring)
Fill it and save

[Screencast from 29-09-25 15:55:33.webm](https://github.com/user-attachments/assets/bc50a488-22f3-41b8-a673-7ec51e6224ac)

<img width="1896" height="800" alt="image" src="https://github.com/user-attachments/assets/52a1b073-fab9-489e-8734-5784a708f0e8" />


2. Check in mongo the data was saved (Optional)

```
docker exec -it tutor_main_dev-mongodb-1 bash
mongosh openedx
db.modulestore.structures.find().sort({ edited_on: -1 }).limit(3)
```


<img width="740" height="800" alt="image" src="https://github.com/user-attachments/assets/9253d2e8-b9bf-4630-a214-edf754a65716" />

Issue [#1484](https://edunext.atlassian.net/browse/FUTUREX-1484)
Migration pr of [#62](https://github.com/nelc/edx-platform/pull/62)
