### PR TITLE
feat: prefill custom fields in the registration form with TPA data

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2658,6 +2658,12 @@ REGISTRATION_EXTENSION_FORM = None  # DEPRECATED: Use PROFILE_EXTENSION_FORM ins
 # To get the new capabilities, migrate to PROFILE_EXTENSION_FORM.
 PROFILE_EXTENSION_FORM = None
 
+# .. setting_name: REGISTRATION_EXTENSION_FORM_FIELDS_TPA_OVERRIDES
+# .. setting_default: []
+# .. setting_description: List of custom fields included in the registriation
+#      form extension to be prefilled with third party auth data.
+REGISTRATION_EXTENSION_FORM_FIELDS_TPA_OVERRIDES = []
+
 # Identifier included in the User Agent from Open edX mobile apps.
 MOBILE_APP_USER_AGENT_REGEXES = [
     r'edX/org.edx.mobile',

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -1325,8 +1325,13 @@ class RegistrationFormFactory:
                             current_provider.skip_registration_form and enterprise_customer_for_request(request)
                         ) or current_provider.sync_learner_profile_data
                     )
+                    registration_fields = (
+                        self.DEFAULT_FIELDS
+                        + self.EXTRA_FIELDS
+                        + settings.REGISTRATION_EXTENSION_FORM_FIELDS_TPA_OVERRIDES
+                    )
 
-                    for field_name in self.DEFAULT_FIELDS + self.EXTRA_FIELDS:
+                    for field_name in registration_fields:
                         if field_name not in field_overrides:
                             continue
 


### PR DESCRIPTION
## Description

This PR enables prefilling custom fields in the registration extension form using data received from a Third-Party Authentication provider (IdP).

It introduces a new Django setting, `REGISTRATION_EXTENSION_FORM_FIELDS_TPA_OVERRIDES`, which allows administrators to define a list of custom fields that should be populated automatically from TPA data during registration.

## Proposed Changes

* Added `REGISTRATION_EXTENSION_FORM_FIELDS_TPA_OVERRIDES` setting in settings configuration with default `[]`.
* Updated TPA registration logic to combine `DEFAULT_FIELDS`, `EXTRA_FIELDS`, and `REGISTRATION_EXTENSION_FORM_FIELDS_TPA_OVERRIDES` into the `registration_fields` list evaluated for field overrides.

## How to Test

1. Configure a Third-Party Auth (TPA) pipeline with an IdP sending custom user attributes.
2. Add custom extension fields to `REGISTRATION_EXTENSION_FORM_FIELDS_TPA_OVERRIDES` in your settings.
```
FEATURES['ENABLE_AUTHN_MICROFRONTEND'] = False
REGISTRATION_EXTENSION_FORM = "custom_reg_form.forms.ExtraInfoForm"
REGISTRATION_EXTENSION_FORM_FIELDS_TPA_OVERRIDES = ["arabic_name"]
```
3. Initiate a sign-up via the configured TPA provider.
4. Verify that the specified custom fields are automatically prefilled on the registration form.


https://github.com/user-attachments/assets/c88784e0-e381-40a7-82f3-02a52f67e72c



### Before
<img width="1654" height="969" alt="image" src="https://github.com/user-attachments/assets/a7844ef1-ea07-4e0b-a5a1-26e2a63e97bb" />


### After
<img width="1618" height="968" alt="image" src="https://github.com/user-attachments/assets/48a2b8db-f3a9-4cb2-8552-884dd2a6301d" />


Issue [#1485](https://edunext.atlassian.net/browse/FUTUREX-1485)
Migration pr of [#63](https://github.com/nelc/edx-platform/pull/63)