### PR TITLE
feat: move progress related apis permissions to standard permission f…

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/views.py
@@ -17,6 +17,7 @@ from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.certificates.api import certificates_viewable_for_course
 from lms.djangoapps.course_api.api import course_detail
 from lms.djangoapps.course_goals.models import UserActivity
+from lms.djangoapps.course_home_api import permissions
 from lms.djangoapps.course_home_api.course_metadata.serializers import CourseHomeMetadataSerializer
 from lms.djangoapps.course_home_api.toggles import new_discussion_sidebar_view_is_enabled
 from lms.djangoapps.courseware.access import has_access, has_cms_access
@@ -83,6 +84,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
         course_key = CourseKey.from_string(course_key_string)
         original_user_is_global_staff = self.request.user.is_staff  # noqa: F841
         original_user_is_staff = has_access(request.user, 'staff', course_key).has_access
+        user_can_masquerade = request.user.has_perm(permissions.CAN_MASQUERADE_LEARNER_PROGRESS, course_key)
 
         try:
             course = course_detail(request, request.user.username, course_key)
@@ -100,7 +102,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
             course,
             request.user,
             'load',
-            check_if_enrolled=True,
+            check_if_enrolled=(not user_can_masquerade),
             check_if_authenticated=True,
             apply_enterprise_checks=True,
         )
@@ -108,7 +110,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
         _, request.user = setup_masquerade(
             request,
             course_key,
-            staff_access=original_user_is_staff,
+            staff_access=user_can_masquerade,
             reset_masquerade_data=True,
         )
 

--- a/lms/djangoapps/course_home_api/permissions.py
+++ b/lms/djangoapps/course_home_api/permissions.py
@@ -1,0 +1,10 @@
+"""
+Permissions for the course home apis and associated actions
+"""
+from bridgekeeper import perms
+
+from lms.djangoapps.courseware.rules import HasAccessRule
+
+CAN_MASQUERADE_LEARNER_PROGRESS = 'course_home_api.can_masquerade_progress'
+
+perms[CAN_MASQUERADE_LEARNER_PROGRESS] = HasAccessRule('staff')

--- a/lms/djangoapps/course_home_api/progress/views.py
+++ b/lms/djangoapps/course_home_api/progress/views.py
@@ -17,6 +17,7 @@ from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.ccx.custom_exception import CCXLocatorValidationException
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.course_blocks.transformers import start_date
+from lms.djangoapps.course_home_api import permissions
 from lms.djangoapps.course_home_api.progress.api import aggregate_assignment_type_grade_summary
 from lms.djangoapps.course_home_api.progress.serializers import ProgressTabSerializer
 from lms.djangoapps.course_home_api.toggles import course_home_mfe_progress_tab_is_active
@@ -198,9 +199,9 @@ class ProgressTabView(RetrieveAPIView):
         monitoring_utils.set_custom_attribute('course_id', course_key_string)
         monitoring_utils.set_custom_attribute('user_id', request.user.id)
         monitoring_utils.set_custom_attribute('is_staff', request.user.is_staff)
-        requester_has_staff_access = bool(has_access(request.user, 'staff', course_key))
+        can_masquerade = request.user.has_perm(permissions.CAN_MASQUERADE_LEARNER_PROGRESS, course_key)
 
-        student = self._get_student_user(request, course_key, student_id, requester_has_staff_access)
+        student = self._get_student_user(request, course_key, student_id, can_masquerade)
         learner_has_staff_access = bool(has_access(student, 'staff', course_key))
         username = get_enterprise_learner_generic_name(request) or student.username
 
@@ -210,7 +211,7 @@ class ProgressTabView(RetrieveAPIView):
         enrollment = CourseEnrollment.get_enrollment(student, course_key)
         enrollment_mode = getattr(enrollment, 'mode', None)
 
-        if not (enrollment and enrollment.is_active) and not requester_has_staff_access:
+        if not (enrollment and enrollment.is_active) and not can_masquerade:
             return Response('User not enrolled.', status=401)
 
         # The block structure is used for both the course_grade and has_scheduled content fields

--- a/lms/djangoapps/course_home_api/tests/test_permissions.py
+++ b/lms/djangoapps/course_home_api/tests/test_permissions.py
@@ -1,0 +1,67 @@
+"""
+Tests for permissions defined in courseware.rules
+"""
+import ddt
+
+from common.djangoapps.student.roles import CourseStaffRole, OrgStaffRole
+from common.djangoapps.student.tests.factories import UserFactory
+from lms.djangoapps.course_home_api.permissions import CAN_MASQUERADE_LEARNER_PROGRESS
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty
+from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty
+
+
+@ddt.ddt
+class PermissionTests(ModuleStoreTestCase):
+    """
+    Tests for permissions defined in courseware.rules
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+        self.course = CourseFactory(org='org')
+        self.another_course = CourseFactory(org='org')
+
+    @ddt.data(
+        (
+            True, None, None, True,
+            "Global staff users should have masquerade access",
+        ),
+        (
+            False, None, None, False,
+            "Non-staff users shouldn't have masquerade access",
+        ),
+        (
+            False, 'another_org', None, False,
+            "User with staff access on another org shouldn't have masquerade access",
+        ),
+        (
+            False, 'org', None, True,
+            "User with org-wide staff access should have masquerade access",
+        ),
+        (
+            False, None, 'another_course', False,
+            "User with staff access on another course shouldn't have masquerade access",
+        ),
+        (
+            False, None, 'course', True,
+            "User with staff access on the course should have masquerade access",
+        ),
+    )
+    @ddt.unpack
+    def test_can_masquerade_return_value(self, is_staff, org_role, course_role, expected_permission, description):
+        """
+        Test that only authorized users have masquerade access
+        """
+        self.user.is_staff = is_staff
+        self.user.save()
+        assert self.user.is_staff == is_staff
+
+        if org_role:
+            OrgStaffRole(org_role).add_users(self.user)
+
+        if course_role:
+            CourseStaffRole(getattr(self, course_role).id).add_users(self.user)
+
+        has_perm = self.user.has_perm(CAN_MASQUERADE_LEARNER_PROGRESS, self.course.id)
+        assert has_perm == expected_permission, description


### PR DESCRIPTION
## Description

feat: standardize `course_home_api` permissions and fix masquerade typo

This PR refactors permission checks in `course_home_api` by defining a standard permission file (`permissions.py`) and registering `CAN_MASQUERADE_LEARNER_PROGRESS` (`course_home_api.can_masquerade_progress`) in Bridgekeeper.

While the default access within `edx-platform` remains restricted to `staff` (`HasAccessRule('staff')`), moving this permission to the Bridgekeeper dictionary allows external packages and plugins (such as `futurex-openedx-extensions`) to dynamically override or extend this key at runtime (e.g., granting access to custom roles like `data_researcher` as required by NeLC).

This PR also fixes the `masquarade` -> `masquerade` typo across the constant, string key, and view references.

## Changes Made

- **`lms/djangoapps/course_home_api/permissions.py`**: Defined `CAN_MASQUERADE_LEARNER_PROGRESS` and registered `course_home_api.can_masquerade_progress` with `HasAccessRule('staff')`.
- **`lms/djangoapps/course_home_api/progress/views.py`**: Updated view to check `request.user.has_perm(permissions.CAN_MASQUERADE_LEARNER_PROGRESS, course_key)`.
- **`lms/djangoapps/course_home_api/course_metadata/views.py`**: Updated view to check `request.user.has_perm(permissions.CAN_MASQUERADE_LEARNER_PROGRESS, course_key)`.

## Supporting Information

- **Context**: Addresses NeLC requirement to allow `data_researcher` role access on the learner progress page via downstream plugin override.
- **Note on Functionality**: This PR introduces no behavioral changes on its own within `edx-platform`, as default permissions remain tied to `staff`.

## How to Test

Since default permissions remain unchanged in `edx-platform`, business logic changes cannot be tested in isolation here. However, you can verify the technical registration:

1. **Verify Bridgekeeper Registration**:
   - Open a Django shell (`python manage.py lms shell`).
   - Check that the new permission key is registered in Bridgekeeper:
     ```python
     from bridgekeeper import perms
     assert 'course_home_api.can_masquerade_progress' in perms
     ```
Issue [# 1561](https://edunext.atlassian.net/browse/FUTUREX-1561)
Migration PR of [#65](https://github.com/nelc/edx-platform/pull/65)

#### Note:
openedx-futurex-extension must be updated