### PR TITLE
perf(user_api): implement centralized caching for user preferences

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_index.py
@@ -161,7 +161,7 @@ class CourseIndexViewTest(CourseTestCase, PermissionAccessMixin):
         """
         Test to check number of queries made to mysql and mongo
         """
-        with self.assertNumQueries(34, table_ignorelist=WAFFLE_TABLES):
+        with self.assertNumQueries(33, table_ignorelist=WAFFLE_TABLES):
             with check_mongo_calls(3):
                 self.client.get(self.url)
 

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -227,7 +227,7 @@ class TestCourseOutline(CourseTestCase):
         """
         Test to check number of queries made to mysql and mongo
         """
-        with self.assertNumQueries(21, table_ignorelist=WAFFLE_TABLES):
+        with self.assertNumQueries(20, table_ignorelist=WAFFLE_TABLES):
             with check_mongo_calls(3):
                 self.client.get(reverse_course_url('course_handler', self.course.id), content_type="application/json")
 

--- a/lms/djangoapps/certificates/apis/v0/tests/test_views.py
+++ b/lms/djangoapps/certificates/apis/v0/tests/test_views.py
@@ -333,7 +333,7 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
             assert len(resp.data) == 0
 
         # Test student with 1 certificate
-        with self.assertNumQueries(13, table_ignorelist=WAFFLE_TABLES):
+        with self.assertNumQueries(12, table_ignorelist=WAFFLE_TABLES):
             resp = self.get_response(
                 AuthType.jwt,
                 requesting_user=self.global_staff,
@@ -373,7 +373,7 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
             download_url='www.google.com',
             grade="0.88",
         )
-        with self.assertNumQueries(13, table_ignorelist=WAFFLE_TABLES):
+        with self.assertNumQueries(12, table_ignorelist=WAFFLE_TABLES):
             resp = self.get_response(
                 AuthType.jwt,
                 requesting_user=self.global_staff,

--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -446,7 +446,7 @@ class CourseListSearchViewTest(CourseApiTestViewMixin, ModuleStoreTestCase, Sear
         self.setup_user(self.audit_user)
 
         # These query counts were found empirically
-        query_counts = [57, 46, 46, 46, 46, 46, 46, 46, 46, 43, 12]
+        query_counts = [56, 44, 44, 44, 44, 44, 44, 44, 44, 41, 10]
         ordered_course_ids = sorted([str(cid) for cid in (course_ids + [c.id for c in self.courses])], key=str.lower)
 
         self.clear_caches()

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1280,8 +1280,8 @@ class ProgressPageTests(ProgressPageBaseTests):
             self.assertContains(resp, "earned a certificate for this course.")
 
     @ddt.data(
-        (True, 56),
-        (False, 56),
+        (True, 54),
+        (False, 54),
     )
     @ddt.unpack
     def test_progress_queries_paced_courses(self, self_paced, query_count):
@@ -1296,13 +1296,13 @@ class ProgressPageTests(ProgressPageBaseTests):
         ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
         self.setup_course()
         with self.assertNumQueries(
-            56, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST
+            54, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST
         ), check_mongo_calls(2):
             self._get_progress_page()
 
         for _ in range(2):
             with self.assertNumQueries(
-                39, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST
+                36, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST
             ), check_mongo_calls(2):
                 self._get_progress_page()
 

--- a/openedx/core/djangoapps/bookmarks/tests/test_views.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_views.py
@@ -268,7 +268,7 @@ class BookmarksListViewTests(BookmarksViewsTestsBase):
         assert response.data['developer_message'] == 'Parameter usage_id not provided.'
 
         # Send empty data dictionary.
-        with self.assertNumQueries(9):  # No queries for bookmark table.
+        with self.assertNumQueries(7):  # No queries for bookmark table.
             response = self.send_post(
                 client=self.client,
                 url=reverse('bookmarks'),

--- a/openedx/core/djangoapps/content_libraries/tests/test_containers.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_containers.py
@@ -801,7 +801,7 @@ class ContainersTestCase(ContentLibrariesRestApiTest):
         assert unit_as_read['collections'] == [{"title": col1.title, "key": col1.collection_code}]
 
     def test_section_hierarchy(self):
-        with self.assertNumQueries(126):
+        with self.assertNumQueries(124):
             hierarchy = self._get_container_hierarchy(self.section_with_subsections["id"])
         assert hierarchy["object_key"] == self.section_with_subsections["id"]
         assert hierarchy["components"] == [
@@ -827,7 +827,7 @@ class ContainersTestCase(ContentLibrariesRestApiTest):
         ]
 
     def test_subsection_hierarchy(self):
-        with self.assertNumQueries(91):
+        with self.assertNumQueries(89):
             hierarchy = self._get_container_hierarchy(self.subsection_with_units["id"])
         assert hierarchy["object_key"] == self.subsection_with_units["id"]
         assert hierarchy["components"] == [
@@ -850,7 +850,7 @@ class ContainersTestCase(ContentLibrariesRestApiTest):
         ]
 
     def test_units_hierarchy(self):
-        with self.assertNumQueries(56):
+        with self.assertNumQueries(54):
             hierarchy = self._get_container_hierarchy(self.unit_with_components["id"])
         assert hierarchy["object_key"] == self.unit_with_components["id"]
         assert hierarchy["components"] == [
@@ -876,7 +876,7 @@ class ContainersTestCase(ContentLibrariesRestApiTest):
         )
 
     def test_block_hierarchy(self):
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(22):
             hierarchy = self._get_block_hierarchy(self.problem_block["id"])
         assert hierarchy["object_key"] == self.problem_block["id"]
         assert hierarchy["components"] == [

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
@@ -520,13 +520,13 @@ class TestTaxonomyListCreateViewSet(TestTaxonomyObjectsMixin, APITestCase):
                 assert response.data["orgs"] == [self.orgA.short_name]
 
     @ddt.data(
-        ('staff', 11),
-        ("content_creatorA", 23),
-        ("library_staffA", 23),
-        ("library_userA", 23),
-        ("instructorA", 23),
-        ("course_instructorA", 23),
-        ("course_staffA", 23),
+        ('staff', 10),
+        ("content_creatorA", 22),
+        ("library_staffA", 22),
+        ("library_userA", 22),
+        ("instructorA", 22),
+        ("course_instructorA", 22),
+        ("course_staffA", 22),
     )
     @ddt.unpack
     def test_list_taxonomy_query_count(self, user_attr: str, expected_queries: int):
@@ -1980,19 +1980,19 @@ class TestObjectTagViewSet(TestObjectTagMixin, APITestCase):
         assert response.data[str(object_id_2)]["taxonomies"] == expected_tags
 
     @ddt.data(
-        ('staff', 'courseA', 10),
-        ('staff', 'libraryA', 17),
-        ('staff', 'collection_key', 17),
-        ("content_creatorA", 'courseA', 20, False),
-        ("content_creatorA", 'libraryA', 23, False),
-        ("content_creatorA", 'collection_key', 23, False),
-        ("library_staffA", 'libraryA', 23, False),  # Library users can only view objecttags, not change them?
-        ("library_staffA", 'collection_key', 23, False),
-        ("library_userA", 'libraryA', 23, False),
-        ("library_userA", 'collection_key', 23, False),
-        ("instructorA", 'courseA', 20),
-        ("course_instructorA", 'courseA', 20),
-        ("course_staffA", 'courseA', 20),
+        ('staff', 'courseA', 9),
+        ('staff', 'libraryA', 16),
+        ('staff', 'collection_key', 16),
+        ("content_creatorA", 'courseA', 19, False),
+        ("content_creatorA", 'libraryA', 22, False),
+        ("content_creatorA", 'collection_key', 22, False),
+        ("library_staffA", 'libraryA', 22, False),  # Library users can only view objecttags, not change them?
+        ("library_staffA", 'collection_key', 22, False),
+        ("library_userA", 'libraryA', 22, False),
+        ("library_userA", 'collection_key', 22, False),
+        ("instructorA", 'courseA', 19),
+        ("course_instructorA", 'courseA', 19),
+        ("course_staffA", 'courseA', 19),
     )
     @ddt.unpack
     def test_object_tags_query_count(
@@ -2878,13 +2878,13 @@ class TestTaxonomyTagsViewSet(TestTaxonomyObjectsMixin, APITestCase):
     Test cases for TaxonomyTagsViewSet retrive action.
     """
     @ddt.data(
-        ('staff', 11),
-        ("content_creatorA", 13),
-        ("library_staffA", 13),
-        ("library_userA", 13),
-        ("instructorA", 13),
-        ("course_instructorA", 13),
-        ("course_staffA", 13),
+        ('staff', 10),
+        ("content_creatorA", 12),
+        ("library_staffA", 12),
+        ("library_userA", 12),
+        ("instructorA", 12),
+        ("course_instructorA", 12),
+        ("course_staffA", 12),
     )
     @ddt.unpack
     def test_taxonomy_tags_query_count(self, user_attr: str, expected_queries: int):

--- a/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
@@ -42,6 +42,7 @@ class TestUserPreferenceMiddleware(CacheIsolationTestCase):
     """
     Tests to make sure user preferences are getting properly set in the middleware.
     """
+    ENABLED_CACHES = ['default']
 
     def setUp(self):
         super().setUp()
@@ -228,7 +229,7 @@ class TestUserPreferenceMiddleware(CacheIsolationTestCase):
 
         response = mock.Mock(spec=HttpResponse)
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(0):
             self.middleware.process_response(self.request, response)
 
         # Preference is the same as the cookie, shouldn't write to the database
@@ -240,7 +241,7 @@ class TestUserPreferenceMiddleware(CacheIsolationTestCase):
 
         response = mock.Mock(spec=HttpResponse)
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(0):
             self.middleware.process_response(self.request, response)
 
         # Cookie changed, should write to the database again
@@ -249,7 +250,7 @@ class TestUserPreferenceMiddleware(CacheIsolationTestCase):
         self.middleware.process_request(self.request)
         assert get_user_preference(self.user, LANGUAGE_KEY) == 'en'
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(0):
             self.middleware.process_response(self.request, response)
 
     @mock.patch('openedx.core.djangoapps.lang_pref.middleware.is_request_from_mobile_app')

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -235,7 +235,7 @@ class TestOwnUsernameAPI(FilteredQueryCountMixin, CacheIsolationTestCase, UserAP
         Test that a client (logged in) can get her own username.
         """
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        self._verify_get_own_username(18)
+        self._verify_get_own_username(17)
 
     def test_get_username_inactive(self):
         """
@@ -245,7 +245,7 @@ class TestOwnUsernameAPI(FilteredQueryCountMixin, CacheIsolationTestCase, UserAP
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
         self.user.is_active = False
         self.user.save()
-        self._verify_get_own_username(18)
+        self._verify_get_own_username(17)
 
     def test_get_username_not_logged_in(self):
         """
@@ -361,7 +361,7 @@ class TestAccountsAPI(FilteredQueryCountMixin, CacheIsolationTestCase, UserAPITe
     """
 
     ENABLED_CACHES = ['default']
-    TOTAL_QUERY_COUNT = 25
+    TOTAL_QUERY_COUNT = 24
     FULL_RESPONSE_FIELD_COUNT = 28
 
     def setUp(self):
@@ -815,12 +815,12 @@ class TestAccountsAPI(FilteredQueryCountMixin, CacheIsolationTestCase, UserAPITe
             assert data['time_zone'] is None
 
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        verify_get_own_information(self._get_num_queries(23))
+        verify_get_own_information(self._get_num_queries(22))
 
         # Now make sure that the user can get the same information, even if not active
         self.user.is_active = False
         self.user.save()
-        verify_get_own_information(self._get_num_queries(15))
+        verify_get_own_information(self._get_num_queries(13))
 
     def test_get_account_empty_string(self):
         """
@@ -835,7 +835,7 @@ class TestAccountsAPI(FilteredQueryCountMixin, CacheIsolationTestCase, UserAPITe
         legacy_profile.save()
 
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        with self.assertNumQueries(self._get_num_queries(23), table_ignorelist=WAFFLE_TABLES):
+        with self.assertNumQueries(self._get_num_queries(22), table_ignorelist=WAFFLE_TABLES):
             response = self.send_get(self.client)
         for empty_field in ("level_of_education", "gender", "country", "state", "bio",):
             assert response.data[empty_field] is None

--- a/openedx/core/djangoapps/user_api/helpers.py
+++ b/openedx/core/djangoapps/user_api/helpers.py
@@ -2,8 +2,6 @@
 Helper functions for the account/profile Python APIs.
 This is NOT part of the public API.
 """
-
-
 import json
 import logging
 import traceback
@@ -12,11 +10,71 @@ from functools import wraps
 
 from django import forms
 from django.conf import settings
+from django.core.cache import cache
 from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.encoding import force_str
 from django.utils.functional import Promise
 
 LOGGER = logging.getLogger(__name__)
+
+USER_PREFERENCE_CACHE_TIMEOUT = getattr(settings, 'USER_PREFERENCE_CACHE_TIMEOUT', 5 * 60)
+USER_PREFERENCE_CACHE_KEY_PREFIX = getattr(settings, 'USER_PREFERENCE_CACHE_KEY_PREFIX', 'user_preferences')
+
+
+def user_preferences_cache_key(user_id):
+    """
+    Generate a unique cache key for a specific user's preferences.
+
+    Args:
+        user_id (int|str): The unique identifier of the user.
+
+    Returns:
+        str: A formatted cache key string.
+    """
+    return f"{USER_PREFERENCE_CACHE_KEY_PREFIX}.{user_id}"
+
+
+def get_cached_preferences(user):
+    """
+    Retrieve the cached preferences dictionary for a given user.
+
+    Args:
+        user (User): The user object whose preferences are being requested.
+
+    Returns:
+        dict|None: The cached preferences if found, otherwise None on a cache miss.
+    """
+    return cache.get(user_preferences_cache_key(user.id))
+
+
+def set_cached_preferences(user, preferences):
+    """
+    Store the user's preferences in the cache.
+
+    Args:
+        user (User): The user object associated with the preferences.
+        preferences (dict): A dictionary containing the user's preference settings.
+
+    Returns:
+        None
+    """
+    cache.set(user_preferences_cache_key(user.id), preferences, USER_PREFERENCE_CACHE_TIMEOUT)
+
+
+def invalidate_user_preferences_cache(user):
+    """
+    Remove the cached preferences for a specific user.
+
+    This should be called whenever user preferences are updated to ensure
+    cache consistency.
+
+    Args:
+        user (User): The user object whose cache entry needs to be deleted.
+
+    Returns:
+        None
+    """
+    cache.delete(user_preferences_cache_key(user.id))
 
 
 def intercept_errors(api_error, ignore_errors=None):

--- a/openedx/core/djangoapps/user_api/models.py
+++ b/openedx/core/djangoapps/user_api/models.py
@@ -16,8 +16,8 @@ from opaque_keys.edx.django.models import CourseKeyField
 # pylint: disable=unused-import
 from common.djangoapps.student.models import get_retired_email_by_email, get_retired_username_by_username
 from common.djangoapps.util.model_utils import emit_settings_changed_event, get_changed_fields_dict
+from openedx.core.djangoapps.user_api.helpers import get_cached_preferences, set_cached_preferences
 from openedx.core.djangolib.model_mixins import DeletableByUserValue
-from openedx.core.lib.cache_utils import request_cached
 
 # Currently, the "student" app is responsible for
 # accounts, profiles, enrollments, and the student dashboard.
@@ -47,14 +47,19 @@ class UserPreference(models.Model):  # noqa: DJ008
         unique_together = ("user", "key")
 
     @staticmethod
-    @request_cached()
     def get_all_preferences(user):
         """
         Gets all preferences for a given user
 
         Returns: Set of (preference type, value) pairs for each of the user's preferences
         """
-        return {pref.key: pref.value for pref in user.preferences.all()}
+        preferences = get_cached_preferences(user)
+
+        if preferences is None:
+            preferences = {pref.key: pref.value for pref in user.preferences.all()}
+            set_cached_preferences(user, preferences)
+
+        return preferences
 
     @classmethod
     def get_value(cls, user, preference_key, default=None):

--- a/openedx/core/djangoapps/user_api/preferences/api.py
+++ b/openedx/core/djangoapps/user_api/preferences/api.py
@@ -26,7 +26,7 @@ from ..errors import (  # lint-amnesty, pylint: disable=unused-import
     UserNotAuthorized,
     UserNotFound,
 )
-from ..helpers import intercept_errors, serializer_is_dirty
+from ..helpers import intercept_errors, invalidate_user_preferences_cache, serializer_is_dirty
 from ..models import UserOrgTag, UserPreference
 from ..serializers import RawUserPreferenceSerializer
 
@@ -55,7 +55,8 @@ def has_user_preference(requesting_user, preference_key, username=None):
          UserAPIInternalError: the operation failed due to an unexpected error.
     """
     existing_user = _get_authorized_user(requesting_user, username, allow_staff=True)
-    return UserPreference.has_value(existing_user, preference_key)
+    preferences = UserPreference.get_all_preferences(existing_user)
+    return preference_key in preferences
 
 
 @intercept_errors(UserAPIInternalError, ignore_errors=[UserAPIRequestError])
@@ -80,7 +81,8 @@ def get_user_preference(requesting_user, preference_key, username=None):
          UserAPIInternalError: the operation failed due to an unexpected error.
     """
     existing_user = _get_authorized_user(requesting_user, username, allow_staff=True)
-    return UserPreference.get_value(existing_user, preference_key)
+    preferences = UserPreference.get_all_preferences(existing_user)
+    return preferences.get(preference_key)
 
 
 @intercept_errors(UserAPIInternalError, ignore_errors=[UserAPIRequestError])
@@ -171,6 +173,7 @@ def update_user_preferences(requesting_user, update, user=None):
                 raise _create_preference_update_error(preference_key, preference_value, error)  # lint-amnesty, pylint: disable=raise-missing-from  # noqa: B904
         else:
             delete_user_preference(requesting_user, preference_key)
+    invalidate_user_preferences_cache(user)
 
 
 @intercept_errors(UserAPIInternalError, ignore_errors=[UserAPIRequestError])
@@ -209,6 +212,7 @@ def set_user_preference(requesting_user, preference_key, preference_value, usern
             serializer.save()
         except Exception as error:
             raise _create_preference_update_error(preference_key, preference_value, error)  # lint-amnesty, pylint: disable=raise-missing-from  # noqa: B904
+        invalidate_user_preferences_cache(existing_user)
 
 
 @intercept_errors(UserAPIInternalError, ignore_errors=[UserAPIRequestError])
@@ -254,6 +258,7 @@ def delete_user_preference(requesting_user, preference_key, username=None):
                 preference_key=preference_key
             ),
         )
+    invalidate_user_preferences_cache(existing_user)
     return True
 
 

--- a/openedx/features/course_experience/tests/views/test_course_updates.py
+++ b/openedx/features/course_experience/tests/views/test_course_updates.py
@@ -50,7 +50,7 @@ class TestCourseUpdatesPage(BaseCourseUpdatesTestCase):
 
         # Fetch the view and verify that the query counts haven't changed
         # TODO: decrease query count as part of REVO-28
-        with self.assertNumQueries(54, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
+        with self.assertNumQueries(52, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
             with check_mongo_calls(3):
                 url = course_updates_url(self.course)
                 self.client.get(url)


### PR DESCRIPTION
## Description

This PR introduces a centralized caching mechanism for the User Preferences API to mitigate severe database load and reduce redundant queries across the platform.

Previously, frequent user preference lookups were causing high operational impact, specifically driven by the user preference lookup query.

```sql
SELECT `user_api_userpreference`.`id`, `user_api_userpreference`.`user_id`, `user_api_userpreference`.`key`, `user_api_userpreference`.`value` FROM `user_api_userpreference` WHERE (`user_api_userpreference`.`key` = ? AND `user_api_userpreference`.`user_id` = ?) LIMIT ?
```

By centralizing the cache at the Model layer using Django's standard caching framework, this PR stabilizes the database, improves global cache utilization, and simplifies the API layer.

## Key Changes

* **Model-Layer Caching:** Removed the `@request_cached()` decorator from `UserPreference.get_all_preferences()` in `models.py`. The cache Hit/Miss logic is now explicitly handled inside this method.
* **Centralized Cache Helpers:** Extracted cache key generation, get, set, and invalidate methods into `openedx/core/djangoapps/user_api/helpers.py`.
* **API Simplification:** Cleaned up `api.py`. Methods like `has_user_preference`, `get_user_preference`, and `get_user_preferences` now directly delegate to the model layer rather than handling caching themselves.

## Testing & Impact

* **Reduced Query Counts:** Successfully reduced expected database queries for preference lookups (e.g., expected queries in `lang_pref/tests/test_middleware.py` dropped from 1 to 0 and 3 to 2; taxonomy tags test queries reduced by 1).
* **Test Environment Updates:** Added `@override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}})` to affected test cases (like `IndexQueryTestCase`). Since the architecture no longer relies on thread-local memory, tests that previously defaulted to `DummyCache` now require a functional cache backend to accurately assert the optimized query counts.

Issue [# 1743](https://edunext.atlassian.net/browse/FUTUREX-1743)
Migration pr of [#71](https://github.com/nelc/edx-platform/pull/71) and [#74](https://github.com/nelc/edx-platform/pull/74)